### PR TITLE
correct namespace in DNS name

### DIFF
--- a/20dns.yml
+++ b/20dns.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ports:
   - port: 9092
-  # [podname].broker.default.svc.cluster.local
+  # [podname].broker.kafka.svc.cluster.local
   clusterIP: None
   selector:
     app: kafka


### PR DESCRIPTION
I noticed this small discrepancy in the comment. the namespace should be `kafka` instead of `default`.