### PR TITLE
Store kafka data inside /opt/kafka/data regardless of image config

### DIFF
--- a/50kafka.yml
+++ b/50kafka.yml
@@ -23,7 +23,7 @@ spec:
         command:
         - sh
         - -c
-        - "./bin/kafka-server-start.sh config/server.properties --override broker.id=$(hostname | awk -F'-' '{print $2}')"
+        - "./bin/kafka-server-start.sh config/server.properties --override broker.id=$(hostname | awk -F'-' '{print $2}') --override log.dirs=/opt/kafka/data/topics"
         volumeMounts:
         - name: datadir
           mountPath: /opt/kafka/data


### PR DESCRIPTION
Thanks to @allenj in https://github.com/Yolean/kubernetes-kafka/issues/11#issuecomment-259283761

First commit fixes this regardless of the kafka image used.