### PR TITLE
Use same kafka image for testclient, as its previous one lacked the -…

### DIFF
--- a/test/99testclient.yml
+++ b/test/99testclient.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: kafka
-    image: solsson/kafka:0.10.0.1
+    image: solsson/kafka-persistent:0.10.1@sha256:110f9e866acd4fb9e059b45884c34a210b2f40d6e2f8afe98ded616f43b599f9
     command:
       - sh
       - -c


### PR DESCRIPTION
…-offset option for the kafka-console-consumer.sh client