### PR TITLE
Added missing namespace from zoo service.

### DIFF
--- a/zookeeper/20zoo-service.yml
+++ b/zookeeper/20zoo-service.yml
@@ -4,6 +4,7 @@ metadata:
   name: zoo
   labels:
     app: zookeeper
+  namespace: kafka
 spec:
   ports:
   - port: 2888


### PR DESCRIPTION
Added the zookeeper/zoo service to the kafka namespace as it was incorrectly being placed in default.