### PR TITLE
Add metrics exporter for Prometheus

### DIFF
--- a/50kafka.yml
+++ b/50kafka.yml
@@ -10,11 +10,21 @@ spec:
     metadata:
       labels:
         app: kafka
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "5556"
     spec:
       terminationGracePeriodSeconds: 10
       containers:
+      - name: metrics
+        image: solsson/kafka-prometheus-jmx-exporter
+        ports:
+        - containerPort: 5556
       - name: broker
         image: solsson/kafka:0.11.0.0-rc2@sha256:c1316e0131f4ec83bc645ca2141e4fda94e0d28f4fb5f836e15e37a5e054bdf1
+        env:
+        - name: JMX_PORT
+          value: "5555"
         ports:
         - containerPort: 9092
         command:

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: metrics
-        image: solsson/kafka-prometheus-jmx-exporter
+        image: solsson/kafka-prometheus-jmx-exporter@sha256:1f7c96c287a2dbec1d909cd8f96c0656310239b55a9a90d7fd12c81f384f1f7d
         ports:
         - containerPort: 5556
       - name: broker

--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ Testing and retesting... delete the namespace. PVs are outside namespaces so del
 kubectl delete namespace kafka
 rm -R ./data/ && kubectl -n kafka delete pv datadir-kafka-0 datadir-kafka-1 datadir-kafka-2
 ```
+
+## Metrics, Prometheus style
+
+Is the metrics system up and running?
+```
+kubectl logs -c metrics kafka-0
+kubectl exec -c broker kafka-0 -- /bin/sh -c 'apk add --no-cache curl && curl http://localhost:5556/metrics'
+```


### PR DESCRIPTION
Compatible with https://github.com/Yolean/kubernetes-monitoring and probably most other Kubernetes + Prometheus setups. Should be useful with the Grafana dashboard from https://github.com/rama-nallamilli/kafka-prometheus-monitoring/blob/master/dashboards/Kafka.json.

Unlike https://github.com/rama-nallamilli/kafka-prometheus-monitoring/blob/master/prometheus-jmx-exporter/confd/templates/kafka.yml.tmpl I saw no reason to make the JMX_PORT configurable, as there's no need to export it outside the pod (a benefit with k8s compared to docker-compose). To tweak configuration I suggest a ConfigMap with the metrics setup.