### PR TITLE
Use persistent volumes for Zookeeper, and use the Kafka image

### DIFF
--- a/50kafka.yml
+++ b/50kafka.yml
@@ -34,11 +34,11 @@ spec:
           ./bin/kafka-server-start.sh
           config/server.properties
           --override log.retention.hours=-1
-          --override log.dirs=/opt/kafka/data/topics
+          --override log.dirs=/var/lib/kafka/data/topics
           --override broker.id=${HOSTNAME##*-}
         volumeMounts:
         - name: datadir
-          mountPath: /opt/kafka/data
+          mountPath: /var/lib/kafka/data
   volumeClaimTemplates:
   - metadata:
       name: datadir

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -1,0 +1,24 @@
+kind: ConfigMap
+metadata:
+  name: zookeeper-config
+  namespace: kafka
+apiVersion: v1
+data:
+  zookeeper.properties: |-
+    tickTime=2000
+    dataDir=/var/lib/zookeeper/data
+    dataLogDir=/var/lib/zookeeper/log
+    clientPort=2181
+    initLimit=5
+    syncLimit=2
+    server.1=zoo-0.zoo:2888:3888:participant
+    server.2=zoo-1.zoo:2888:3888:participant
+    server.3=zoo-2.zoo:2888:3888:participant
+    server.4=zoo-3.zoo:2888:3888:participant
+    server.5=zoo-4.zoo:2888:3888:participant
+    
+  log4j.properties: |-
+    log4j.rootLogger=INFO, stdout
+    log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+    log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+    log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n

--- a/zookeeper/50zoo.yml
+++ b/zookeeper/50zoo.yml
@@ -14,10 +14,17 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: zookeeper
-        image: solsson/zookeeper-statefulset:3.4.10@sha256:0ad93c98d5165b4eb747c4b0dd04a7a448a5c4b4cbcaa4bffc15018b76b81bb5
-        env:
-        - name: ZOO_SERVERS
-          value: server.1=zoo-0.zoo:2888:3888:participant server.2=zoo-1.zoo:2888:3888:participant server.3=zoo-2.zoo:2888:3888:participant server.4=zoo-3.zoo:2888:3888:participant server.5=zoo-4.zoo:2888:3888:participant
+        image: solsson/kafka:0.11.0.0-rc2@sha256:c1316e0131f4ec83bc645ca2141e4fda94e0d28f4fb5f836e15e37a5e054bdf1
+        command:
+        - sh
+        - -c
+        - >
+          set -e;
+          export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + 1));
+          echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid;
+          sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" config/zookeeper.properties;
+          cat config/zookeeper.properties;
+          ./bin/zookeeper-server-start.sh config/zookeeper.properties
         ports:
         - containerPort: 2181
           name: client
@@ -26,13 +33,13 @@ spec:
         - containerPort: 3888
           name: leader-election
         volumeMounts:
+        - name: config
+          mountPath: /usr/local/kafka/config
         - name: datadir
-          mountPath: /data
-        # There's defaults in this folder, such as logging config
-        #- name: conf
-        #  mountPath: /conf
+          mountPath: /var/lib/zookeeper/data
       volumes:
-      #- name: conf
-      #  emptyDir: {}
+      - name: config
+        configMap:
+          name: zookeeper-config
       - name: datadir
         emptyDir: {}


### PR DESCRIPTION
The Kafka distribution already includes Zookeeper's main, so there's no need for us to pull another image.

The README.md used to say:
> If you lose your zookeeper cluster, kafka will be unaware that persisted topics exist. The data is still there, but you need to re-create topics.

But that's a risky assumption if you have partitioning, which we aim to improve at with #30.