### PR TITLE
Suggest a mix of persistent and ephemeral data to improve reliability across zones

### DIFF
--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -11,11 +11,11 @@ data:
     clientPort=2181
     initLimit=5
     syncLimit=2
-    server.1=pzoo-0.zoo:2888:3888:participant
-    server.2=pzoo-1.zoo:2888:3888:participant
-    server.3=pzoo-2.zoo:2888:3888:participant
-    server.4=zoo-3.zoo:2888:3888:participant
-    server.5=zoo-4.zoo:2888:3888:participant
+    server.1=pzoo-0.pzoo:2888:3888:participant
+    server.2=pzoo-1.pzoo:2888:3888:participant
+    server.3=pzoo-2.pzoo:2888:3888:participant
+    server.4=zoo-0.zoo:2888:3888:participant
+    server.5=zoo-1.zoo:2888:3888:participant
     
   log4j.properties: |-
     log4j.rootLogger=INFO, stdout

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -11,9 +11,9 @@ data:
     clientPort=2181
     initLimit=5
     syncLimit=2
-    server.1=zoo-0.zoo:2888:3888:participant
-    server.2=zoo-1.zoo:2888:3888:participant
-    server.3=zoo-2.zoo:2888:3888:participant
+    server.1=pzoo-0.zoo:2888:3888:participant
+    server.2=pzoo-1.zoo:2888:3888:participant
+    server.3=pzoo-2.zoo:2888:3888:participant
     server.4=zoo-3.zoo:2888:3888:participant
     server.5=zoo-4.zoo:2888:3888:participant
     

--- a/zookeeper/20pzoo-service.yml
+++ b/zookeeper/20pzoo-service.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: zoo
+  name: pzoo
   namespace: kafka
 spec:
   ports:
@@ -12,3 +12,4 @@ spec:
   clusterIP: None
   selector:
     app: zookeeper
+    storage: persistent

--- a/zookeeper/21zoo-service.yml
+++ b/zookeeper/21zoo-service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pzoo
+  namespace: kafka
+spec:
+  ports:
+  - port: 2888
+    name: peer
+  - port: 3888
+    name: leader-election
+  clusterIP: None
+  selector:
+    app: zookeeper
+    storage: persistent

--- a/zookeeper/21zoo-service.yml
+++ b/zookeeper/21zoo-service.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: pzoo
+  name: zoo
   namespace: kafka
 spec:
   ports:
@@ -12,4 +12,4 @@ spec:
   clusterIP: None
   selector:
     app: zookeeper
-    storage: persistent
+    storage: ephemeral

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -1,15 +1,16 @@
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: zoo
+  name: pzoo
   namespace: kafka
 spec:
-  serviceName: "zoo"
+  serviceName: "pzoo"
   replicas: 5
   template:
     metadata:
       labels:
         app: zookeeper
+        storage: persistent
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "5556"

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: kafka
 spec:
   serviceName: "pzoo"
-  replicas: 5
+  replicas: 3
   template:
     metadata:
       labels:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: pzoo
+  namespace: kafka
+spec:
+  serviceName: "pzoo"
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+        storage: persistent
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "5556"
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: metrics
+        image: solsson/kafka-prometheus-jmx-exporter@sha256:1f7c96c287a2dbec1d909cd8f96c0656310239b55a9a90d7fd12c81f384f1f7d
+        command:
+        - "java"
+        - "-jar"
+        - "jmx_prometheus_httpserver.jar"
+        - "5556"
+        - example_configs/zookeeper.yaml
+        ports:
+        - containerPort: 5556
+      - name: zookeeper
+        image: solsson/kafka:0.11.0.0-rc2@sha256:c1316e0131f4ec83bc645ca2141e4fda94e0d28f4fb5f836e15e37a5e054bdf1
+        env:
+        - name: JMX_PORT
+          value: "5555"
+        command:
+        - sh
+        - -c
+        - >
+          set -e;
+          export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + 1));
+          echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid;
+          sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" config/zookeeper.properties;
+          cat config/zookeeper.properties;
+          ./bin/zookeeper-server-start.sh config/zookeeper.properties
+        ports:
+        - containerPort: 2181
+          name: client
+        - containerPort: 2888
+          name: peer
+        - containerPort: 3888
+          name: leader-election
+        volumeMounts:
+        - name: config
+          mountPath: /usr/local/kafka/config
+        - name: data
+          mountPath: /var/lib/zookeeper/data
+      volumes:
+      - name: config
+        configMap:
+          name: zookeeper-config
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      annotations:
+        volume.beta.kubernetes.io/storage-class: kafka-zookeeper
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: pzoo
+  name: zoo
   namespace: kafka
 spec:
-  serviceName: "pzoo"
-  replicas: 5
+  serviceName: "zoo"
+  replicas: 2
   template:
     metadata:
       labels:
         app: zookeeper
-        storage: persistent
+        storage: ephemeral
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "5556"
@@ -37,7 +37,7 @@ spec:
         - -c
         - >
           set -e;
-          export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + 1));
+          export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + 4));
           echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid;
           sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" config/zookeeper.properties;
           cat config/zookeeper.properties;
@@ -58,13 +58,5 @@ spec:
       - name: config
         configMap:
           name: zookeeper-config
-  volumeClaimTemplates:
-  - metadata:
-      name: data
-      annotations:
-        volume.beta.kubernetes.io/storage-class: kafka-zookeeper
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 1Gi
+      - name: data
+        emptyDir: {}


### PR DESCRIPTION
Goal:
 * With a cluster spanning two or three availability zones, be able to form a quorum even if only one zone is up.
 * If all zookeeper pods die, be able to start them up again with kafka's metadata intact.

Addresses a weakness with PV and multi-zone clusters identified in #33. For evaluation with #30.