### PR TITLE
Update pvc.yml, README

### DIFF
--- a/10pvc.yml
+++ b/10pvc.yml
@@ -9,7 +9,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 200Gi
+      storage: 100Mi
   selector:
     matchLabels:
       app: kafka
@@ -25,7 +25,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 200Gi
+      storage: 100Mi
   selector:
     matchLabels:
       app: kafka
@@ -41,7 +41,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 200Gi
+      storage: 100Mi
   selector:
     matchLabels:
       app: kafka

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ Alternatively create [PV](http://kubernetes.io/docs/user-guide/persistent-volume
 
 ```
 ./bootstrap/pv.sh
-kubectl create -f ./bootstrap/pvc.yml
-# check that claims are bound
-kubectl get pvc
 ```
 
 ## Set up Zookeeper


### PR DESCRIPTION
./bootstrap/pvc.yml doesn't exist anymore and 10pvc.yml will get run
on kubectl create -f ./ so that section of the README isn't needed.

10pvc.yml requests 200Gi while ./bootstrap/pv-template.yml specifies 100Mi,
causing the pvc status to stay in pending indefinitely.