### PR TITLE
Addon: Collect logs to Kafka topic

### DIFF
--- a/addon-logs/logs-kube-kafka.yml
+++ b/addon-logs/logs-kube-kafka.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: kafkacat
-        image: solsson/kafkacat@sha256:36d1f191cc33a8365074280279205e6b4f52cd8cc8fb1b896bb4c943c9dee8f8
+        image: solsson/kafkacat@sha256:ebebf47061300b14a4b4c2e1e4303ab29f65e4b95d34af1b14bb8f7ec6da7cef
         command:
         - sh
         - -ec

--- a/addon-logs/logs-kube-kafka.yml
+++ b/addon-logs/logs-kube-kafka.yml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: logs-kafka
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: logs-kafka
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: kafkacat
+        image: solsson/kafkacat@sha256:36d1f191cc33a8365074280279205e6b4f52cd8cc8fb1b896bb4c943c9dee8f8
+        command:
+        - sh
+        - -ec
+        - 'tail -f /dev/null'
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/addon-logs/logs-kube-kafka.yml
+++ b/addon-logs/logs-kube-kafka.yml
@@ -17,7 +17,19 @@ spec:
         command:
         - sh
         - -ec
-        - 'tail -f /dev/null'
+        - >
+          tail
+          -n 0
+          -f
+          /var/log/containers/*.log
+          |
+          kafkacat
+          -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+          -t ops-kube-logs-raw-001
+          -P
+          -D '\n\n==> '
+          -K ' <==\n'
+          #-z snappy
         resources:
           limits:
             memory: 100Mi

--- a/addon-logs/logs-kube-kafka.yml
+++ b/addon-logs/logs-kube-kafka.yml
@@ -18,17 +18,18 @@ spec:
         - sh
         - -ec
         - >
+          cd /var/log/containers/;
           tail
           -n 0
           -f
-          /var/log/containers/*.log
+          --zero-terminated
+          *.log
           |
           kafkacat
           -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
           -t ops-kube-logs-raw-001
           -P
-          -D '\n\n==> '
-          -K ' <==\n'
+          -D '\0'
           #-z snappy
         resources:
           limits:

--- a/addon-logs/logs-kube-kafka.yml
+++ b/addon-logs/logs-kube-kafka.yml
@@ -21,15 +21,13 @@ spec:
           cd /var/log/containers/;
           tail
           -n 0
-          -f
-          --zero-terminated
+          --follow=name
           *.log
           |
           kafkacat
           -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
           -t ops-kube-logs-raw-001
           -P
-          -D '\0'
           #-z snappy
         resources:
           limits:

--- a/addon-logs/logs-kube-kafka.yml
+++ b/addon-logs/logs-kube-kafka.yml
@@ -27,14 +27,9 @@ spec:
         volumeMounts:
         - name: varlog
           mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
           readOnly: true
       terminationGracePeriodSeconds: 10
       volumes:
       - name: varlog
         hostPath:
           path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers

--- a/addon-logs/topic-ops-kube-logs-raw.yml
+++ b/addon-logs/topic-ops-kube-logs-raw.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/addon-logs/topic-ops-kube-logs-raw.yml
+++ b/addon-logs/topic-ops-kube-logs-raw.yml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: topic-ops-kube-logs-raw
+  namespace: kafka
+spec:
+  template:
+    metadata:
+      labels:
+        app: topic-create
+        topic-id: ops-kube-logs-raw
+        topic-gen: "001"
+    spec:
+      containers:
+      - name: kafka
+        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        command:
+        - ./bin/kafka-topics.sh
+        - --zookeeper
+        - zookeeper:2181
+        - --create
+        - --if-not-exists
+        - --topic
+        - ops-kube-logs-raw-001
+        - --partitions
+        - "1"
+        - --replication-factor
+        - "1"
+        - --config
+        # this might be eight days
+        - retention.ms=69125000
+      restartPolicy: Never


### PR DESCRIPTION
Note that unlike #39 we don't want a test consumer in this addon, becauase it would cause an infinite loop of logging. Use kubectl exec to some kafka(cat) container with a console consumer.

Currently two blockers:
 * `tail -f *.log` won't discover new files
 * can't use the filename headers from tail -f as delimiters because kafkacat supports only single char delimiters.

Maybe a dedicated tool like fluent-bit is required for proper log folder processing.