### PR TITLE
Mount config and use debian based image

### DIFF
--- a/10broker-config.yml
+++ b/10broker-config.yml
@@ -4,6 +4,13 @@ metadata:
   namespace: kafka
 apiVersion: v1
 data:
+  init.sh: |-
+    #!/bin/bash
+    set -x
+
+    export KAFKA_BROKER_ID=${HOSTNAME##*-}
+    sed -i "s/\${KAFKA_BROKER_ID}/$KAFKA_BROKER_ID/" /etc/kafka/server.properties
+
   server.properties: |-
     # Licensed to the Apache Software Foundation (ASF) under one or more
     # contributor license agreements.  See the NOTICE file distributed with
@@ -25,7 +32,7 @@ data:
     ############################# Server Basics #############################
 
     # The id of the broker. This must be set to a unique integer for each broker.
-    broker.id=0
+    broker.id=${KAFKA_BROKER_ID}
 
     # Switch to enable topic deletion or not, default value is false
     #delete.topic.enable=true

--- a/10broker-config.yml
+++ b/10broker-config.yml
@@ -1,0 +1,239 @@
+kind: ConfigMap
+metadata:
+  name: broker-config
+  namespace: kafka
+apiVersion: v1
+data:
+  server.properties: |-
+    # Licensed to the Apache Software Foundation (ASF) under one or more
+    # contributor license agreements.  See the NOTICE file distributed with
+    # this work for additional information regarding copyright ownership.
+    # The ASF licenses this file to You under the Apache License, Version 2.0
+    # (the "License"); you may not use this file except in compliance with
+    # the License.  You may obtain a copy of the License at
+    #
+    #    http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    # see kafka.server.KafkaConfig for additional details and defaults
+
+    ############################# Server Basics #############################
+
+    # The id of the broker. This must be set to a unique integer for each broker.
+    broker.id=0
+
+    # Switch to enable topic deletion or not, default value is false
+    #delete.topic.enable=true
+
+    ############################# Socket Server Settings #############################
+
+    # The address the socket server listens on. It will get the value returned from
+    # java.net.InetAddress.getCanonicalHostName() if not configured.
+    #   FORMAT:
+    #     listeners = listener_name://host_name:port
+    #   EXAMPLE:
+    #     listeners = PLAINTEXT://your.host.name:9092
+    #listeners=PLAINTEXT://:9092
+
+    # Hostname and port the broker will advertise to producers and consumers. If not set,
+    # it uses the value for "listeners" if configured.  Otherwise, it will use the value
+    # returned from java.net.InetAddress.getCanonicalHostName().
+    #advertised.listeners=PLAINTEXT://your.host.name:9092
+
+    # Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
+    #listener.security.protocol.map=PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+
+    # The number of threads that the server uses for receiving requests from the network and sending responses to the network
+    num.network.threads=3
+
+    # The number of threads that the server uses for processing requests, which may include disk I/O
+    num.io.threads=8
+
+    # The send buffer (SO_SNDBUF) used by the socket server
+    socket.send.buffer.bytes=102400
+
+    # The receive buffer (SO_RCVBUF) used by the socket server
+    socket.receive.buffer.bytes=102400
+
+    # The maximum size of a request that the socket server will accept (protection against OOM)
+    socket.request.max.bytes=104857600
+
+
+    ############################# Log Basics #############################
+
+    # A comma seperated list of directories under which to store log files
+    log.dirs=/tmp/kafka-logs
+
+    # The default number of log partitions per topic. More partitions allow greater
+    # parallelism for consumption, but this will also result in more files across
+    # the brokers.
+    num.partitions=1
+
+    # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+    # This value is recommended to be increased for installations with data dirs located in RAID array.
+    num.recovery.threads.per.data.dir=1
+
+    ############################# Internal Topic Settings  #############################
+    # The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+    # For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
+    offsets.topic.replication.factor=1
+    transaction.state.log.replication.factor=1
+    transaction.state.log.min.isr=1
+
+    ############################# Log Flush Policy #############################
+
+    # Messages are immediately written to the filesystem but by default we only fsync() to sync
+    # the OS cache lazily. The following configurations control the flush of data to disk.
+    # There are a few important trade-offs here:
+    #    1. Durability: Unflushed data may be lost if you are not using replication.
+    #    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+    #    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to exceessive seeks.
+    # The settings below allow one to configure the flush policy to flush data after a period of time or
+    # every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+    # The number of messages to accept before forcing a flush of data to disk
+    #log.flush.interval.messages=10000
+
+    # The maximum amount of time a message can sit in a log before we force a flush
+    #log.flush.interval.ms=1000
+
+    ############################# Log Retention Policy #############################
+
+    # The following configurations control the disposal of log segments. The policy can
+    # be set to delete segments after a period of time, or after a given size has accumulated.
+    # A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+    # from the end of the log.
+
+    # The minimum age of a log file to be eligible for deletion due to age
+    log.retention.hours=168
+
+    # A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
+    # segments don't drop below log.retention.bytes. Functions independently of log.retention.hours.
+    #log.retention.bytes=1073741824
+
+    # The maximum size of a log segment file. When this size is reached a new log segment will be created.
+    log.segment.bytes=1073741824
+
+    # The interval at which log segments are checked to see if they can be deleted according
+    # to the retention policies
+    log.retention.check.interval.ms=300000
+
+    ############################# Zookeeper #############################
+
+    # Zookeeper connection string (see zookeeper docs for details).
+    # This is a comma separated host:port pairs, each corresponding to a zk
+    # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+    # You can also append an optional chroot string to the urls to specify the
+    # root directory for all kafka znodes.
+    zookeeper.connect=localhost:2181
+
+    # Timeout in ms for connecting to zookeeper
+    zookeeper.connection.timeout.ms=6000
+
+
+    ############################# Group Coordinator Settings #############################
+
+    # The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
+    # The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms.
+    # The default value for this is 3 seconds.
+    # We override this to 0 here as it makes for a better out-of-the-box experience for development and testing.
+    # However, in production environments the default value of 3 seconds is more suitable as this will help to avoid unnecessary, and potentially expensive, rebalances during application startup.
+    group.initial.rebalance.delay.ms=0
+
+  log4j.properties: |-
+    # Licensed to the Apache Software Foundation (ASF) under one or more
+    # contributor license agreements.  See the NOTICE file distributed with
+    # this work for additional information regarding copyright ownership.
+    # The ASF licenses this file to You under the Apache License, Version 2.0
+    # (the "License"); you may not use this file except in compliance with
+    # the License.  You may obtain a copy of the License at
+    #
+    #    http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    # Unspecified loggers and loggers with additivity=true output to server.log and stdout
+    # Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
+    log4j.rootLogger=INFO, stdout, kafkaAppender
+
+    log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+    log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+    log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
+    log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
+    log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
+    log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
+    log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    log4j.appender.stateChangeAppender=org.apache.log4j.DailyRollingFileAppender
+    log4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH
+    log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
+    log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
+    log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
+    log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
+    log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
+    log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
+    log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    log4j.appender.cleanerAppender=org.apache.log4j.DailyRollingFileAppender
+    log4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH
+    log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
+    log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
+    log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    log4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender
+    log4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH
+    log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
+    log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
+    log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    log4j.appender.authorizerAppender=org.apache.log4j.DailyRollingFileAppender
+    log4j.appender.authorizerAppender.DatePattern='.'yyyy-MM-dd-HH
+    log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
+    log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
+    log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    # Change the two lines below to adjust ZK client logging
+    log4j.logger.org.I0Itec.zkclient.ZkClient=INFO
+    log4j.logger.org.apache.zookeeper=INFO
+
+    # Change the two lines below to adjust the general broker logging level (output to server.log and stdout)
+    log4j.logger.kafka=INFO
+    log4j.logger.org.apache.kafka=INFO
+
+    # Change to DEBUG or TRACE to enable request logging
+    log4j.logger.kafka.request.logger=WARN, requestAppender
+    log4j.additivity.kafka.request.logger=false
+
+    # Uncomment the lines below and change log4j.logger.kafka.network.RequestChannel$ to TRACE for additional output
+    # related to the handling of requests
+    #log4j.logger.kafka.network.Processor=TRACE, requestAppender
+    #log4j.logger.kafka.server.KafkaApis=TRACE, requestAppender
+    #log4j.additivity.kafka.server.KafkaApis=false
+    log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
+    log4j.additivity.kafka.network.RequestChannel$=false
+
+    log4j.logger.kafka.controller=TRACE, controllerAppender
+    log4j.additivity.kafka.controller=false
+
+    log4j.logger.kafka.log.LogCleaner=INFO, cleanerAppender
+    log4j.additivity.kafka.log.LogCleaner=false
+
+    log4j.logger.state.change.logger=TRACE, stateChangeAppender
+    log4j.additivity.state.change.logger=false
+
+    # Change to DEBUG to enable audit log for the authorizer
+    log4j.logger.kafka.authorizer.logger=WARN, authorizerAppender
+    log4j.additivity.kafka.authorizer.logger=false

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -28,7 +28,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: broker
-        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
+        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         env:
         - name: JMX_PORT
           value: "5555"

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -28,7 +28,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: broker
-        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/opt/kafka/config/log4j.properties

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -40,6 +40,7 @@ spec:
         - >
           ./bin/kafka-server-start.sh
           config/server.properties
+          --override zookeeper.connect=zookeeper:2181
           --override log.retention.hours=-1
           --override log.dirs=/var/lib/kafka/data/topics
           --override broker.id=${HOSTNAME##*-}
@@ -54,8 +55,14 @@ spec:
             - -c
             - 'echo "" | nc -w 1 127.0.0.1 9092'
         volumeMounts:
+        - name: config
+          mountPath: /opt/kafka/config
         - name: data
           mountPath: /var/lib/kafka/data
+      volumes:
+      - name: config
+        configMap:
+          name: broker-config
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -15,6 +15,13 @@ spec:
         prometheus.io/port: "5556"
     spec:
       terminationGracePeriodSeconds: 30
+      initContainers:
+      - name: init-config
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
+        command: ['/bin/bash', '/etc/kafka/init.sh']
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kafka
       containers:
       - name: metrics
         image: solsson/kafka-prometheus-jmx-exporter@sha256:1f7c96c287a2dbec1d909cd8f96c0656310239b55a9a90d7fd12c81f384f1f7d
@@ -31,22 +38,22 @@ spec:
         image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         env:
         - name: KAFKA_LOG4J_OPTS
-          value: -Dlog4j.configuration=file:/opt/kafka/config/log4j.properties
+          value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         - name: JMX_PORT
           value: "5555"
         ports:
         - containerPort: 9092
         command:
-        - /bin/sh
-        - -c
-        - >
-          ./bin/kafka-server-start.sh
-          ./config/server.properties
-          --override zookeeper.connect=zookeeper:2181
-          --override log.retention.hours=-1
-          --override log.dirs=/var/lib/kafka/data/topics
-          --override broker.id=${HOSTNAME##*-}
-          --override auto.create.topics.enable=false
+        - ./bin/kafka-server-start.sh
+        - /etc/kafka/server.properties
+        - --override
+        -   zookeeper.connect=zookeeper:2181
+        - --override
+        -   log.retention.hours=-1
+        - --override
+        -   log.dirs=/var/lib/kafka/data/topics
+        - --override
+        -   auto.create.topics.enable=false
         resources:
           requests:
             cpu: 100m
@@ -59,7 +66,7 @@ spec:
             - 'echo "" | nc -w 1 127.0.0.1 9092'
         volumeMounts:
         - name: config
-          mountPath: /opt/kafka/config
+          mountPath: /etc/kafka
         - name: data
           mountPath: /var/lib/kafka/data
       volumes:

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -44,6 +44,7 @@ spec:
           --override log.retention.hours=-1
           --override log.dirs=/var/lib/kafka/data/topics
           --override broker.id=${HOSTNAME##*-}
+          --override auto.create.topics.enable=false
         resources:
           requests:
             cpu: 100m

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -30,6 +30,8 @@ spec:
       - name: broker
         image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         env:
+        - name: KAFKA_LOG4J_OPTS
+          value: -Dlog4j.configuration=file:/opt/kafka/config/log4j.properties
         - name: JMX_PORT
           value: "5555"
         ports:
@@ -39,7 +41,7 @@ spec:
         - -c
         - >
           ./bin/kafka-server-start.sh
-          config/server.properties
+          ./config/server.properties
           --override zookeeper.connect=zookeeper:2181
           --override log.retention.hours=-1
           --override log.dirs=/var/lib/kafka/data/topics

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -35,7 +35,7 @@ spec:
         ports:
         - containerPort: 9092
         command:
-        - /bin/bash
+        - /bin/sh
         - -c
         - >
           ./bin/kafka-server-start.sh

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -28,7 +28,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: broker
-        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
         env:
         - name: JMX_PORT
           value: "5555"

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -28,7 +28,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: broker
-        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
+        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
         env:
         - name: JMX_PORT
           value: "5555"

--- a/test/11topic-create-test1.yml
+++ b/test/11topic-create-test1.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
+        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/test/11topic-create-test1.yml
+++ b/test/11topic-create-test1.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/test/11topic-create-test1.yml
+++ b/test/11topic-create-test1.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
+        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/test/11topic-create-test1.yml
+++ b/test/11topic-create-test1.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/test/12topic-create-test2.yml
+++ b/test/12topic-create-test2.yml
@@ -22,4 +22,6 @@ spec:
         - "1"
         - --replication-factor
         - "3"
+        - --config
+        - min.insync.replicas=2
       restartPolicy: Never

--- a/test/12topic-create-test2.yml
+++ b/test/12topic-create-test2.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
+        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/test/12topic-create-test2.yml
+++ b/test/12topic-create-test2.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/test/12topic-create-test2.yml
+++ b/test/12topic-create-test2.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
+        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/test/12topic-create-test2.yml
+++ b/test/12topic-create-test2.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/test/21consumer-test1.yml
+++ b/test/21consumer-test1.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         command:
         - ./bin/kafka-console-consumer.sh
         - --bootstrap-server

--- a/test/21consumer-test1.yml
+++ b/test/21consumer-test1.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
         command:
         - ./bin/kafka-console-consumer.sh
         - --bootstrap-server

--- a/test/21consumer-test1.yml
+++ b/test/21consumer-test1.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
+        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
         command:
         - ./bin/kafka-console-consumer.sh
         - --bootstrap-server

--- a/test/21consumer-test1.yml
+++ b/test/21consumer-test1.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
+        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         command:
         - ./bin/kafka-console-consumer.sh
         - --bootstrap-server

--- a/test/31producer-test1.yml
+++ b/test/31producer-test1.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
+        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
         command:
         - /bin/sh
         - -c

--- a/test/31producer-test1.yml
+++ b/test/31producer-test1.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         command:
         - /bin/sh
         - -c

--- a/test/31producer-test1.yml
+++ b/test/31producer-test1.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
+        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         command:
         - /bin/sh
         - -c

--- a/test/31producer-test1.yml
+++ b/test/31producer-test1.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
         command:
         - /bin/sh
         - -c

--- a/test/99testclient.yml
+++ b/test/99testclient.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: kafka
-    image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
+    image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
     command:
       - sh
       - -c

--- a/test/99testclient.yml
+++ b/test/99testclient.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: kafka
-    image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
+    image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
     command:
       - sh
       - -c

--- a/test/99testclient.yml
+++ b/test/99testclient.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: kafka
-    image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
+    image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
     command:
       - sh
       - -c

--- a/test/99testclient.yml
+++ b/test/99testclient.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: kafka
-    image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+    image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
     command:
       - sh
       - -c

--- a/update-kafka-image.sh
+++ b/update-kafka-image.sh
@@ -3,6 +3,8 @@
 IMAGE=$1
 [ -z "$IMAGE" ] && echo "First argument should be the image to set" && exit 1
 
+[[ $IMAGE != solsson/kafka:* ]] && echo "Should be the full image identifier" && exit 1
+
 for F in ./ test/ zookeeper/; do
   sed -i "s|image: solsson/kafka:.*|image: $IMAGE|" $F*.yml
 done

--- a/update-kafka-image.sh
+++ b/update-kafka-image.sh
@@ -4,5 +4,5 @@ IMAGE=$1
 [ -z "$IMAGE" ] && echo "First argument should be the image to set" && exit 1
 
 for F in ./ test/ zookeeper/; do
-  sed -i '' "s|image: solsson/kafka:.*|image: $IMAGE|" $F*.yml
+  sed -i "s|image: solsson/kafka:.*|image: $IMAGE|" $F*.yml
 done

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -4,6 +4,15 @@ metadata:
   namespace: kafka
 apiVersion: v1
 data:
+  init.sh: |-
+    #!/bin/bash
+    set -x
+
+    [ -z "$ID_OFFSET" ] && ID_OFFSET=1
+    export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + $ID_OFFSET))
+    echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid
+    sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" /etc/kafka/zookeeper.properties
+
   zookeeper.properties: |-
     tickTime=2000
     dataDir=/var/lib/zookeeper/data
@@ -16,9 +25,13 @@ data:
     server.3=pzoo-2.pzoo:2888:3888:participant
     server.4=zoo-0.zoo:2888:3888:participant
     server.5=zoo-1.zoo:2888:3888:participant
-    
+
   log4j.properties: |-
     log4j.rootLogger=INFO, stdout
     log4j.appender.stdout=org.apache.log4j.ConsoleAppender
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    # Suppress connection log messages, three lines per livenessProbe execution
+    log4j.logger.org.apache.zookeeper.server.NIOServerCnxnFactory=WARN
+    log4j.logger.org.apache.zookeeper.server.NIOServerCnxn=WARN

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -75,7 +75,7 @@ spec:
             - '[ "imok" = "$(echo ruok | nc -w 1 127.0.0.1 2181)" ]'
         volumeMounts:
         - name: config
-          mountPath: /usr/local/kafka/config
+          mountPath: /opt/kafka/config
         - name: data
           mountPath: /var/lib/zookeeper/data
       volumes:

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -37,7 +37,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: zookeeper
-        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
         env:
         - name: JMX_PORT
           value: "5555"

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -37,7 +37,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: zookeeper
-        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/opt/kafka/config/log4j.properties

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -66,13 +66,13 @@ spec:
             command:
             - /bin/sh
             - -c
-            - '[ "imok" == $(echo "ruok" | nc -w 1 127.0.0.1 2181) ]'
+            - '[ "imok" = "$(echo ruok | nc -w 1 127.0.0.1 2181)" ]'
         readinessProbe:
           exec:
             command:
             - /bin/sh
             - -c
-            - '[ "imok" == $(echo "ruok" | nc -w 1 127.0.0.1 2181) ]'
+            - '[ "imok" = "$(echo ruok | nc -w 1 127.0.0.1 2181)" ]'
         volumeMounts:
         - name: config
           mountPath: /usr/local/kafka/config

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -16,6 +16,15 @@ spec:
         prometheus.io/port: "5556"
     spec:
       terminationGracePeriodSeconds: 10
+      initContainers:
+      - name: init-config
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
+        command: ['/bin/bash', '/etc/kafka/init.sh']
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kafka
+        - name: data
+          mountPath: /var/lib/zookeeper/data
       containers:
       - name: metrics
         image: solsson/kafka-prometheus-jmx-exporter@sha256:1f7c96c287a2dbec1d909cd8f96c0656310239b55a9a90d7fd12c81f384f1f7d
@@ -40,18 +49,12 @@ spec:
         image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         env:
         - name: KAFKA_LOG4J_OPTS
-          value: -Dlog4j.configuration=file:/opt/kafka/config/log4j.properties
+          value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         - name: JMX_PORT
           value: "5555"
         command:
-        - /bin/sh
-        - -euc
-        - >
-          export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + 1));
-          echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid;
-          sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" config/zookeeper.properties;
-          cat config/zookeeper.properties;
-          ./bin/zookeeper-server-start.sh config/zookeeper.properties
+        - ./bin/zookeeper-server-start.sh
+        - /etc/kafka/zookeeper.properties
         ports:
         - containerPort: 2181
           name: client
@@ -77,7 +80,7 @@ spec:
             - '[ "imok" = "$(echo ruok | nc -w 1 127.0.0.1 2181)" ]'
         volumeMounts:
         - name: config
-          mountPath: /opt/kafka/config
+          mountPath: /etc/kafka
         - name: data
           mountPath: /var/lib/zookeeper/data
       volumes:

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -42,7 +42,7 @@ spec:
         - name: JMX_PORT
           value: "5555"
         command:
-        - /bin/bash
+        - /bin/sh
         - -euc
         - >
           export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + 1));

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -37,7 +37,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: zookeeper
-        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
+        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         env:
         - name: JMX_PORT
           value: "5555"

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -39,6 +39,8 @@ spec:
       - name: zookeeper
         image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         env:
+        - name: KAFKA_LOG4J_OPTS
+          value: -Dlog4j.configuration=file:/opt/kafka/config/log4j.properties
         - name: JMX_PORT
           value: "5555"
         command:

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -37,7 +37,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: zookeeper
-        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
+        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
         env:
         - name: JMX_PORT
           value: "5555"

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -75,7 +75,7 @@ spec:
             - '[ "imok" = "$(echo ruok | nc -w 1 127.0.0.1 2181)" ]'
         volumeMounts:
         - name: config
-          mountPath: /usr/local/kafka/config
+          mountPath: /opt/kafka/config
         - name: data
           mountPath: /var/lib/zookeeper/data
       volumes:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -37,7 +37,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: zookeeper
-        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
         env:
         - name: JMX_PORT
           value: "5555"

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -37,7 +37,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: zookeeper
-        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/opt/kafka/config/log4j.properties

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -66,13 +66,13 @@ spec:
             command:
             - /bin/sh
             - -c
-            - '[ "imok" == $(echo "ruok" | nc -w 1 127.0.0.1 2181) ]'
+            - '[ "imok" = "$(echo ruok | nc -w 1 127.0.0.1 2181)" ]'
         readinessProbe:
           exec:
             command:
             - /bin/sh
             - -c
-            - '[ "imok" == $(echo "ruok" | nc -w 1 127.0.0.1 2181) ]'
+            - '[ "imok" = "$(echo ruok | nc -w 1 127.0.0.1 2181)" ]'
         volumeMounts:
         - name: config
           mountPath: /usr/local/kafka/config

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -16,6 +16,18 @@ spec:
         prometheus.io/port: "5556"
     spec:
       terminationGracePeriodSeconds: 10
+      initContainers:
+      - name: init-config
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
+        command: ['/bin/bash', '/etc/kafka/init.sh']
+        env:
+        - name: ID_OFFSET
+          value: "4"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kafka
+        - name: data
+          mountPath: /var/lib/zookeeper/data
       containers:
       - name: metrics
         image: solsson/kafka-prometheus-jmx-exporter@sha256:1f7c96c287a2dbec1d909cd8f96c0656310239b55a9a90d7fd12c81f384f1f7d
@@ -40,18 +52,12 @@ spec:
         image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         env:
         - name: KAFKA_LOG4J_OPTS
-          value: -Dlog4j.configuration=file:/opt/kafka/config/log4j.properties
+          value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         - name: JMX_PORT
           value: "5555"
         command:
-        - /bin/sh
-        - -euc
-        - >
-          export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + 4));
-          echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid;
-          sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" config/zookeeper.properties;
-          cat config/zookeeper.properties;
-          ./bin/zookeeper-server-start.sh config/zookeeper.properties
+        - ./bin/zookeeper-server-start.sh
+        - /etc/kafka/zookeeper.properties
         ports:
         - containerPort: 2181
           name: client
@@ -77,7 +83,7 @@ spec:
             - '[ "imok" = "$(echo ruok | nc -w 1 127.0.0.1 2181)" ]'
         volumeMounts:
         - name: config
-          mountPath: /opt/kafka/config
+          mountPath: /etc/kafka
         - name: data
           mountPath: /var/lib/zookeeper/data
       volumes:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -37,7 +37,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: zookeeper
-        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
+        image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         env:
         - name: JMX_PORT
           value: "5555"

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -42,7 +42,7 @@ spec:
         - name: JMX_PORT
           value: "5555"
         command:
-        - /bin/bash
+        - /bin/sh
         - -euc
         - >
           export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + 4));

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -39,6 +39,8 @@ spec:
       - name: zookeeper
         image: solsson/kafka:0.11.0.0@sha256:e0dec6aa1f376bd374a6ca5863b783d01703acf1f71c0c4441a217a7bd80dfbc
         env:
+        - name: KAFKA_LOG4J_OPTS
+          value: -Dlog4j.configuration=file:/opt/kafka/config/log4j.properties
         - name: JMX_PORT
           value: "5555"
         command:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -37,7 +37,7 @@ spec:
             cpu: 10m
             memory: 100Mi
       - name: zookeeper
-        image: solsson/kafka:0.11.0.0@sha256:92c5092d7c2f10abd11693731f6e112d40bfd42d6428a7cdf0516c9666dd3e58
+        image: solsson/kafka:0.11.0.0@sha256:df808192488b280e3bee7a271208032a5669e0e58d4aebe83500492ebaea342b
         env:
         - name: JMX_PORT
           value: "5555"


### PR DESCRIPTION
We're adding ever more `--override` commands, as seen in for example https://github.com/Yolean/kubernetes-kafka/issues/13#issuecomment-317749903. #41 will require some amazing bash one-line stuff, or that we use a script to modify the properties file. To keep options open here I'm (re-)introducing a ConfigMap for Kafka server start.

With this change we have to reflect on the assumptions we make about the Kafka image. Choice of shell and paths affect Kubernetes manifests. Choice of base image (contestant are Debian and Alpine) profoundly affects how the projects matures WRT for example resource limits. Maturity with Alpine would mean we risk lots if regressions if we switch. Thus I wanted to do some image work, as motivated https://github.com/solsson/dockerfiles/pull/5.

I'm still hesitant about https://github.com/solsson/dockerfiles/pull/10. The image will be a leaky abstraction anyway, and drop-in replacements are unlikely for the same reason as above of maturing.