### PR TITLE
Addon: bootstrap.kafka service with current brokers as endpoint

### DIFF
--- a/30bootstrap-service.yml
+++ b/30bootstrap-service.yml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bootstrap
+  namespace: kafka
+spec:
+  ports:
+  - port: 9092
+  selector:
+    app: kafka

--- a/test/basic-with-kafkacat.yml
+++ b/test/basic-with-kafkacat.yml
@@ -72,8 +72,7 @@ spec:
         env:
         - name: BOOTSTRAP
           #value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
-          #value: kafka-0.broker.kafka.svc.cluster.local:9092
-          value: bootstrap.kafka.svc.cluster.local:9092
+          value: kafka-0.broker.kafka.svc.cluster.local:9092
         - name: ZOOKEEPER
           value: zookeeper.kafka.svc.cluster.local:2181
         # Test set up

--- a/test/basic-with-kafkacat.yml
+++ b/test/basic-with-kafkacat.yml
@@ -72,7 +72,8 @@ spec:
         env:
         - name: BOOTSTRAP
           #value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
-          value: kafka-0.broker.kafka.svc.cluster.local:9092
+          #value: kafka-0.broker.kafka.svc.cluster.local:9092
+          value: bootstrap.kafka.svc.cluster.local:9092
         - name: ZOOKEEPER
           value: zookeeper.kafka.svc.cluster.local:2181
         # Test set up


### PR DESCRIPTION
This looks useful but I'm hesitant to merge to master due to #21, which we dealt with by removing the service in #30.

I fail to figure out how to test, let alone enforce, that this service is only used for the initial connection but not for actual consumption or production. Clients should discover brokers through this service, but not suffer from the round-robin nature of it. A danger is that when developing with 1 replica, #44 for example, there is no round-robin and thus no such issues.