### PR TITLE
Enable topic deletion option by default

### DIFF
--- a/10broker-config.yml
+++ b/10broker-config.yml
@@ -35,7 +35,7 @@ data:
     broker.id=${KAFKA_BROKER_ID}
 
     # Switch to enable topic deletion or not, default value is false
-    #delete.topic.enable=true
+    delete.topic.enable=true
 
     ############################# Socket Server Settings #############################
 


### PR DESCRIPTION
Will happen in the October release, so there's no reason to keep it disabled now with the merge of the #30 refactoring and retesting.

https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=71764913

