### PR TITLE
Trigger upgrades automatically on statefulset change

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -11,7 +11,7 @@ spec:
   serviceName: "broker"
   replicas: 3
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -12,7 +12,7 @@ spec:
   serviceName: "pzoo"
   replicas: 3
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -11,7 +11,7 @@ spec:
   serviceName: "zoo"
   replicas: 2
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Any votes on this? No need to do `kubectl delete` manually, but on the other hand the pod restart sequence may come as a surprise. Also I think it requires Kubernetes 1.7.