### PR TITLE
Addon: Stream all Kubernetes events to a topic

### DIFF
--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -35,4 +35,4 @@ spec:
           -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
           -t ops-kube-events-all-json-001
           -P
-          -z gzip
+          -z snappy

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -28,7 +28,7 @@ spec:
           value: ops-kube-events-all-json-001
         command:
         - /bin/bash
-        - -ec
+        - -c
           # curl errors will go to kafka, kafkacat errors will got to log
         - >
           echo "Started at $(date -u +%FT%TZ) producing to $TOPIC"
@@ -46,3 +46,13 @@ spec:
           -z snappy
           -v
           -d broker,topic
+          ;
+          echo "Last message on topic:"
+          ;
+          kafkacat
+          -b $BOOTSTRAP
+          -t $TOPIC
+          -C
+          -o -1
+          -c 1
+          -z snappy

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -21,10 +21,18 @@ spec:
       containers:
       - name: kafkacat-curl
         image: solsson/kafkacat-curl@sha256:6ad61f2e6343359c3972d7a86815568c0a1d0560068134c5d702a152eb5123a0
+        env:
+        - name: BOOTSTRAP
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        - name: TOPIC
+          value: ops-kube-events-all-json-001
         command:
         - /bin/bash
         - -ec
+          # curl errors will go to kafka, kafkacat errors will got to log
         - >
+          echo "Started at $(date -u +%FT%TZ) producing to $TOPIC"
+          ;
           curl
           -s
           --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -32,7 +40,9 @@ spec:
           https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/watch/events
           |
           kafkacat
-          -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
-          -t ops-kube-events-all-json-001
+          -b $BOOTSTRAP
+          -t $TOPIC
           -P
           -z snappy
+          -v
+          -d broker,topic

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -28,12 +28,12 @@ spec:
           value: ops-kube-events-all-json-001
         command:
         - /bin/bash
-        - -c
-          # curl errors will go to kafka, kafkacat errors will got to log
+        - -ec
         - >
           echo "Started at $(date -u +%FT%TZ) producing to $TOPIC"
           ;
           curl
+          -f
           -s
           --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt
           --header "Authorization: Bearer $(cat /run/secrets/kubernetes.io/serviceaccount/token)"
@@ -46,13 +46,3 @@ spec:
           -z snappy
           -v
           -d broker,topic
-          ;
-          echo "Last message on topic:"
-          ;
-          kafkacat
-          -b $BOOTSTRAP
-          -t $TOPIC
-          -C
-          -o -1
-          -c 1
-          -z snappy

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -35,4 +35,4 @@ spec:
           -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
           -t ops-kube-events-all-json-001
           -P
-          -z snappy
+          -z gzip

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -22,6 +22,14 @@ spec:
       - name: kubectl-kafkacat
         image: solsson/kubectl-kafkacat@sha256:e496cb9bca667c5cf629bcedd3a5788affa4c68e9a6a0198d521e9dd6fcaf89b
         command:
-        - sh
+        - /bin/bash
         - -ec
-        - 'tail -f /dev/null'
+        - >
+          kubectl
+          get events
+          -w
+          |
+          kafkacat
+          -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+          -t ops-kube-events-all-json-001
+          -P

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -35,3 +35,4 @@ spec:
           -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
           -t ops-kube-events-all-json-001
           -P
+          -z snappy

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -30,8 +30,6 @@ spec:
         - /bin/bash
         - -ec
         - >
-          echo "Started at $(date -u +%FT%TZ) producing to $TOPIC"
-          ;
           curl
           -f
           -s

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -25,12 +25,14 @@ spec:
         - /bin/bash
         - -ec
         - >
+          echo '
           curl
           --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt
-          --header "Authorization: Bearer $(cat /run/secrets/kubernetes.io/serviceaccont/token)"
+          --header "Authorization: Bearer $(cat /run/secrets/kubernetes.io/serviceaccount/token)"
           https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/watch/events
           |
           kafkacat
           -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
           -t ops-kube-events-all-json-001
           -P
+          '; tail -f /dev/null

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: events-kube-kafka
+  namespace: kafka
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # prefer duplicate events over missed
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: events
+        from: kube
+        to: kafka
+    spec:
+      containers:
+      - name: kubectl-kafkacat
+        image: solsson/kubectl-kafkacat@sha256:e496cb9bca667c5cf629bcedd3a5788affa4c68e9a6a0198d521e9dd6fcaf89b
+        command:
+        - sh
+        - -ec
+        - 'tail -f /dev/null'

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -19,15 +19,16 @@ spec:
         to: kafka
     spec:
       containers:
-      - name: kubectl-kafkacat
-        image: solsson/kubectl-kafkacat@sha256:e496cb9bca667c5cf629bcedd3a5788affa4c68e9a6a0198d521e9dd6fcaf89b
+      - name: kafkacat-curl
+        image: solsson/kafkacat-curl@sha256:26b81296ba1d2c6b2cbce81c644b3b780ab5beab57bebbbb11f0d0a99e2d0d2b
         command:
         - /bin/bash
         - -ec
         - >
-          kubectl
-          get events
-          -w
+          curl
+          --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt
+          --header "Authorization: Bearer $(cat /run/secrets/kubernetes.io/serviceaccont/token)"
+          https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/watch/events
           |
           kafkacat
           -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: kafkacat-curl
-        image: solsson/kafkacat-curl@sha256:26b81296ba1d2c6b2cbce81c644b3b780ab5beab57bebbbb11f0d0a99e2d0d2b
+        image: solsson/kafkacat-curl@sha256:6ad61f2e6343359c3972d7a86815568c0a1d0560068134c5d702a152eb5123a0
         command:
         - /bin/bash
         - -ec

--- a/addon-events/events-kube-kafka.yml
+++ b/addon-events/events-kube-kafka.yml
@@ -25,8 +25,8 @@ spec:
         - /bin/bash
         - -ec
         - >
-          echo '
           curl
+          -s
           --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt
           --header "Authorization: Bearer $(cat /run/secrets/kubernetes.io/serviceaccount/token)"
           https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/watch/events
@@ -35,4 +35,3 @@ spec:
           -b kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
           -t ops-kube-events-all-json-001
           -P
-          '; tail -f /dev/null

--- a/addon-events/test-event-consumer.yml
+++ b/addon-events/test-event-consumer.yml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: test-events-consumer
+  namespace: kafka
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # prefer duplicate events over missed
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: events
+        type: test
+        from: kafka-ops
+    spec:
+      containers:
+      - name: kafkacat
+        image: solsson/kafkacat@sha256:36d1f191cc33a8365074280279205e6b4f52cd8cc8fb1b896bb4c943c9dee8f8
+        command:
+        - kafkacat
+        - -b
+        - kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        - -t
+        - ops-kube-events-all-json-001
+        - -C

--- a/addon-events/topic-ops-kube-events-all-json.yml
+++ b/addon-events/topic-ops-kube-events-all-json.yml
@@ -27,6 +27,6 @@ spec:
         - --replication-factor
         - "1"
         - --config
-        # this might be eight days
-        - retention.ms=69125000
+        # 8 days
+        - retention.ms=691200000  
       restartPolicy: Never

--- a/addon-events/topic-ops-kube-events-all-json.yml
+++ b/addon-events/topic-ops-kube-events-all-json.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        image: solsson/kafka:0.11.0.0@sha256:b27560de08d30ebf96d12e74f80afcaca503ad4ca3103e63b1fd43a2e4c976ce
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/addon-events/topic-ops-kube-events-all-json.yml
+++ b/addon-events/topic-ops-kube-events-all-json.yml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: topic-ops-kube-events-all-json
+  namespace: kafka
+spec:
+  template:
+    metadata:
+      labels:
+        app: topic-create
+        topic-id: ops-kube-events-all-json
+        topic-gen: "001"
+    spec:
+      containers:
+      - name: kafka
+        image: solsson/kafka:0.11.0.0@sha256:4c194db2ec15698aca6f1aa8a2fd5e5c566caed82b4bf43446c388f315397756
+        command:
+        - ./bin/kafka-topics.sh
+        - --zookeeper
+        - zookeeper:2181
+        - --create
+        - --if-not-exists
+        - --topic
+        - ops-kube-events-all-json-001
+        - --partitions
+        - "1"
+        - --replication-factor
+        - "1"
+        - --config
+        # this might be eight days
+        - retention.ms=69125000
+      restartPolicy: Never

--- a/rbac-namespace-default/events-watcher.yml
+++ b/rbac-namespace-default/events-watcher.yml
@@ -1,0 +1,30 @@
+# If events-kube-kafka-* goes crashlooping you probably need this
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: events-watcher
+  labels:
+    origin: github.com_Yolean_kubernetes-kafka
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kafka-events-watcher
+  labels:
+    origin: github.com_Yolean_kubernetes-kafka
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: events-watcher
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kafka

--- a/test/events-topic.yml
+++ b/test/events-topic.yml
@@ -1,8 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: test-events-consumer
-  namespace: kafka
+  name: events-topic
+  namespace: test-kafka
 spec:
   replicas: 1
   strategy:
@@ -14,9 +14,8 @@ spec:
   template:
     metadata:
       labels:
-        app: events
-        type: test
-        from: kafka-ops
+        test-target: events-topic
+        test-type: readiness
     spec:
       containers:
       - name: kafkacat

--- a/test/events-topic.yml
+++ b/test/events-topic.yml
@@ -5,17 +5,12 @@ metadata:
   namespace: test-kafka
 spec:
   replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      # prefer duplicate events over missed
-      maxUnavailable: 0
-      maxSurge: 1
   template:
     metadata:
       labels:
         test-target: events-topic
-        test-type: readiness
+        # Would be a valid testcase if it verifies that >0 messages per some time unit have been produced
+        #test-type: readiness
     spec:
       containers:
       - name: kafkacat


### PR DESCRIPTION
A quite interesting log with messages like (`kubectl -n test-kafka logs -l test-target=events-topic`):
```
{
  "type": "MODIFIED",
  "object": {
    "kind": "Event",
    "apiVersion": "v1",
    "metadata": {
      "name": "pzoo-0.14d7585c3d972d2d",
      "namespace": "kafka",
      "selfLink": "/api/v1/namespaces/kafka/events/pzoo-0.14d7585c3d972d2d",
      "uid": "e0ed084c-784d-11e7-a1b0-42010a840078",
      "resourceVersion": "108989",
      "creationTimestamp": "2017-08-03T13:15:53Z"
    },
    "involvedObject": {
      "kind": "Pod",
      "namespace": "kafka",
      "name": "pzoo-0",
      "uid": "c4d1c2e6-784d-11e7-a1b0-42010a840078",
      "apiVersion": "v1",
      "resourceVersion": "469107",
      "fieldPath": "spec.containers{zookeeper}"
    },
    "reason": "Unhealthy",
    "message": "Readiness probe failed: ",
    "source": {
      "component": "kubelet",
      "host": "gke-eu-west-3-default-pool-f275612a-f7m1"
    },
    "firstTimestamp": "2017-08-03T13:15:53Z",
    "lastTimestamp": "2017-08-05T04:54:23Z",
    "count": 592,
    "type": "Warning"
  }
}
```
(#31 should take note about this particular event)

Reopens #39.

Includes RBAC policy from #59