### PR TITLE
[WIP] prelim set-up of resources to test kafka-connect source/sink demo

### DIFF
--- a/addon-cp/rest.yml
+++ b/addon-cp/rest.yml
@@ -21,6 +21,8 @@ spec:
         env:
         - name: KAFKAREST_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka-rest/log4j.properties
+        - name: REST_PORT
+          value: "80"
         command:
         - kafka-rest-start
         - /etc/kafka-rest/kafka-rest.properties

--- a/connect-test-debezium/Dockerfile
+++ b/connect-test-debezium/Dockerfile
@@ -1,0 +1,9 @@
+FROM debezium/connect:0.6
+
+# Deploy PostgreSQL JDBC Driver
+RUN cd /kafka/libs && curl -sO https://jdbc.postgresql.org/download/postgresql-42.1.4.jar
+
+# Deploy Kafka Connect JDBC
+ENV KAFKA_CONNECT_JDBC_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-jdbc
+RUN mkdir $KAFKA_CONNECT_JDBC_DIR && cd $KAFKA_CONNECT_JDBC_DIR &&\
+	curl -sO http://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/3.3.0/kafka-connect-jdbc-3.3.0.jar

--- a/connect-test-debezium/README.md
+++ b/connect-test-debezium/README.md
@@ -1,0 +1,5 @@
+### Testing kafka-connect in a kubernetes context
+
+This `connect-debezium-test` feature branch is an attempt to get this demonstration [blog post](http://debezium.io/blog/2017/09/25/streaming-to-another-database/) from debezium running.  Debezium are behind a number of source connectors that facilitate change-data-capture from mySQL and postgres.  The also have a source connector for mongodb.
+
+This particular demo uses the mySQL source connector and combines with the Confluent [kafka-connect-jdbc](https://github.com/confluentinc/kafka-connect-jdbc) sink connector in order to replicate changes from the mySQL database to the postgres database via a kafka message bus.

--- a/connect-test-debezium/connect-deployment.yaml
+++ b/connect-test-debezium/connect-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: connect
+  namespace: kafka
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: connect
+    spec:
+      containers:
+      - env:
+        - name: BOOTSTRAP_SERVERS
+          value: broker.kafka:9092
+        - name: CONFIG_STORAGE_TOPIC
+          value: my_connect_configs
+        - name: GROUP_ID
+          value: "1"
+        - name: OFFSET_STORAGE_TOPIC
+          value: my_connect_offsets
+        - name: REST_PORT
+          value: "80"  
+        image: analect/connect-deb-jdbc:0.6
+        name: connect
+        ports:
+        - containerPort: 8083
+        - containerPort: 5005
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/connect-test-debezium/connect-service.yaml
+++ b/connect-test-debezium/connect-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: connect
+  namespace: kafka
+spec:
+  ports:
+  - name: "8083"
+    port: 8083
+    targetPort: 8083
+  - name: "5005"
+    port: 5005
+    targetPort: 5005
+  selector:
+    io.kompose.service: connect
+status:
+  loadBalancer: {}

--- a/connect-test-debezium/mysql-deployment.yaml
+++ b/connect-test-debezium/mysql-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mysql
+  namespace: kafka
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mysql
+    spec:
+      containers:
+      - env:
+        - name: MYSQL_PASSWORD
+          value: mysqlpw
+        - name: MYSQL_ROOT_PASSWORD
+          value: debezium
+        - name: MYSQL_USER
+          value: mysqluser
+        image: debezium/example-mysql:0.6
+        name: mysql
+        ports:
+        - containerPort: 3306
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/connect-test-debezium/mysql-service.yaml
+++ b/connect-test-debezium/mysql-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: kafka
+spec:
+  ports:
+  - name: "3306"
+    port: 3306
+    targetPort: 3306
+  selector:
+    io.kompose.service: mysql
+status:
+  loadBalancer: {}

--- a/connect-test-debezium/postgres-deployment.yaml
+++ b/connect-test-debezium/postgres-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: kafka
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: postgres
+    spec:
+      containers:
+      - env:
+        - name: POSTGRES_DB
+          value: inventory
+        - name: POSTGRES_PASSWORD
+          value: postgrespw
+        - name: POSTGRES_USER
+          value: postgresuser
+        image: debezium/postgres:9.6
+        name: postgres
+        ports:
+        - containerPort: 5432
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/connect-test-debezium/postgres-service.yaml
+++ b/connect-test-debezium/postgres-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: kafka
+spec:
+  ports:
+  - name: "5432"
+    port: 5432
+    targetPort: 5432
+  selector:
+    io.kompose.service: postgres
+status:
+  loadBalancer: {}


### PR DESCRIPTION
@solsson 
In an attempt to take your `addon-connect` branch a step further, I branched to `connect-test-debezium` (this PR) in order to test the set-up in this [blog](http://debezium.io/blog/2017/09/25/streaming-to-another-database/), which seeks to use a debezium source connector for mySQL and a confluent JDBC sink connector.

I created a basic helm chart outside this repo to initially test, which was based on this [docker-compose](https://github.com/debezium/debezium-examples/blob/master/unwrap-smt/docker-compose.yaml) file and was essentially using the various debezium images, which themselves are built on top of the confluent ones, as far as I understand.  This appeared to work well in terms of getting changes in mySQL flowing to postgres.

I then tried to get things working with the same resources in here (although not structured as a helm chart) using your pre-existing set-up for kafka, zookeeper, rest and schema-registry.  However, the connect image is based on the Dockerfile in the PR, which itself is a replica of [this one](https://github.com/debezium/debezium-examples/blob/master/unwrap-smt/debezium-jdbc/Dockerfile).

Initially, I was getting a problem with `Exception in thread "main" org.apache.kafka.common.config.ConfigException: Invalid value tcp://10.7.245.223:80 for configuration rest.port: Not a number of type INT` (see below), where somehow that tcp address above was getting set as an ENV VARIABLE `KAFKA_PORT`.  So I added `REST_PORT` key/value in the `connect-deployment.yaml` which seems to have overcome that problem.

```
2017-10-02 22:42:58,913 INFO   ||  Added alias 'TimestampRouter' to plugin 'org.apache.kafka.connect.transforms.TimestampRouter'   [org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader]
2017-10-02 22:42:58,913 INFO   ||  Added alias 'ValueToKey' to plugin 'org.apache.kafka.connect.transforms.ValueToKey'   [org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader]
Exception in thread "main" org.apache.kafka.common.config.ConfigException: Invalid value tcp://10.7.245.223:80 for configuration rest.port: Not a number of type INT
	at org.apache.kafka.common.config.ConfigDef.parseType(ConfigDef.java:713)
	at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:460)
	at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:453)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:62)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:75)
	at org.apache.kafka.connect.runtime.WorkerConfig.<init>(WorkerConfig.java:197)
	at org.apache.kafka.connect.runtime.distributed.DistributedConfig.<init>(DistributedConfig.java:289)
	at org.apache.kafka.connect.cli.ConnectDistributed.main(ConnectDistributed.java:65)
```
However, as per this [gist](https://gist.github.com/Analect/d0a4142b96db5f6d60b108782def524c), there is still something causing the connector to crash and I was wondering if you might have any insights.  It could be down to something with the connector [image](https://hub.docker.com/r/analect/connect-deb-jdbc/) (built on a debezium image with a confluent plugin/connector on-board) that is somehow not sitting well with your `solsson` images.  Would you have any thoughts on what might be going on here?  Thanks.