### PR TITLE
Remove overrides in manifest command; use property files

### DIFF
--- a/10broker-config.yml
+++ b/10broker-config.yml
@@ -138,7 +138,7 @@ data:
     # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
     # You can also append an optional chroot string to the urls to specify the
     # root directory for all kafka znodes.
-    zookeeper.connect=localhost:2181
+    zookeeper.connect=zookeeper:2181
 
     # Timeout in ms for connecting to zookeeper
     zookeeper.connection.timeout.ms=6000

--- a/10broker-config.yml
+++ b/10broker-config.yml
@@ -35,7 +35,6 @@ data:
     # Switch to enable topic deletion or not, default value is false
     delete.topic.enable=true
 
-    # Yolean/kubernetes-kafka
     auto.create.topics.enable=false
 
     ############################# Socket Server Settings #############################

--- a/10broker-config.yml
+++ b/10broker-config.yml
@@ -118,7 +118,7 @@ data:
     # from the end of the log.
 
     # The minimum age of a log file to be eligible for deletion due to age
-    log.retention.hours=168
+    log.retention.hours=-1
 
     # A size-based retention policy for logs. Segments are pruned from the log unless the remaining
     # segments drop below log.retention.bytes. Functions independently of log.retention.hours.

--- a/10broker-config.yml
+++ b/10broker-config.yml
@@ -25,23 +25,6 @@ data:
     }
 
   server.properties: |-
-    # Licensed to the Apache Software Foundation (ASF) under one or more
-    # contributor license agreements.  See the NOTICE file distributed with
-    # this work for additional information regarding copyright ownership.
-    # The ASF licenses this file to You under the Apache License, Version 2.0
-    # (the "License"); you may not use this file except in compliance with
-    # the License.  You may obtain a copy of the License at
-    #
-    #    http://www.apache.org/licenses/LICENSE-2.0
-    #
-    # Unless required by applicable law or agreed to in writing, software
-    # distributed under the License is distributed on an "AS IS" BASIS,
-    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    # See the License for the specific language governing permissions and
-    # limitations under the License.
-
-    # see kafka.server.KafkaConfig for additional details and defaults
-
     ############################# Server Basics #############################
 
     # The id of the broker. This must be set to a unique integer for each broker.
@@ -134,8 +117,8 @@ data:
     # The minimum age of a log file to be eligible for deletion due to age
     log.retention.hours=168
 
-    # A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
-    # segments don't drop below log.retention.bytes. Functions independently of log.retention.hours.
+    # A size-based retention policy for logs. Segments are pruned from the log unless the remaining
+    # segments drop below log.retention.bytes. Functions independently of log.retention.hours.
     #log.retention.bytes=1073741824
 
     # The maximum size of a log segment file. When this size is reached a new log segment will be created.
@@ -168,23 +151,6 @@ data:
     group.initial.rebalance.delay.ms=0
 
   log4j.properties: |-
-    # Licensed to the Apache Software Foundation (ASF) under one or more
-    # contributor license agreements.  See the NOTICE file distributed with
-    # this work for additional information regarding copyright ownership.
-    # The ASF licenses this file to You under the Apache License, Version 2.0
-    # (the "License"); you may not use this file except in compliance with
-    # the License.  You may obtain a copy of the License at
-    #
-    #    http://www.apache.org/licenses/LICENSE-2.0
-    #
-    # Unless required by applicable law or agreed to in writing, software
-    # distributed under the License is distributed on an "AS IS" BASIS,
-    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    # See the License for the specific language governing permissions and
-    # limitations under the License.
-
-    # Unspecified loggers and loggers with additivity=true output to server.log and stdout
-    # Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
     log4j.rootLogger=INFO, stdout
 
     log4j.appender.stdout=org.apache.log4j.ConsoleAppender
@@ -256,6 +222,6 @@ data:
     log4j.logger.state.change.logger=TRACE, stateChangeAppender
     log4j.additivity.state.change.logger=false
 
-    # Change to DEBUG to enable audit log for the authorizer
-    log4j.logger.kafka.authorizer.logger=WARN, authorizerAppender
+    # Access denials are logged at INFO level, change to DEBUG to also log allowed accesses
+    log4j.logger.kafka.authorizer.logger=INFO, authorizerAppender
     log4j.additivity.kafka.authorizer.logger=false

--- a/10broker-config.yml
+++ b/10broker-config.yml
@@ -35,6 +35,9 @@ data:
     # Switch to enable topic deletion or not, default value is false
     delete.topic.enable=true
 
+    # Yolean/kubernetes-kafka
+    auto.create.topics.enable=false
+
     ############################# Socket Server Settings #############################
 
     # The address the socket server listens on. It will get the value returned from

--- a/10broker-config.yml
+++ b/10broker-config.yml
@@ -75,7 +75,7 @@ data:
     ############################# Log Basics #############################
 
     # A comma seperated list of directories under which to store log files
-    log.dirs=/tmp/kafka-logs
+    log.dirs=/var/lib/kafka/data/topics
 
     # The default number of log partitions per topic. More partitions allow greater
     # parallelism for consumption, but this will also result in more files across

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -37,8 +37,6 @@ spec:
         - ./bin/kafka-server-start.sh
         - /etc/kafka/server.properties
         - --override
-        -   zookeeper.connect=zookeeper:2181
-        - --override
         -   log.dirs=/var/lib/kafka/data/topics
         resources:
           requests:

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -36,8 +36,6 @@ spec:
         command:
         - ./bin/kafka-server-start.sh
         - /etc/kafka/server.properties
-        - --override
-        -   log.dirs=/var/lib/kafka/data/topics
         resources:
           requests:
             cpu: 100m

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -42,8 +42,6 @@ spec:
         -   log.retention.hours=-1
         - --override
         -   log.dirs=/var/lib/kafka/data/topics
-        - --override
-        -   auto.create.topics.enable=false
         resources:
           requests:
             cpu: 100m

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -39,8 +39,6 @@ spec:
         - --override
         -   zookeeper.connect=zookeeper:2181
         - --override
-        -   log.retention.hours=-1
-        - --override
         -   log.dirs=/var/lib/kafka/data/topics
         resources:
           requests:


### PR DESCRIPTION
As pointed out in #72 we were inconsistent, having a gotcha with the workflow that you edit .properties based on reading kafka docs.

Until now we kept `.properties` equal to kafka source's examples, sort of. We had already deviated through #41 and 1899096, and we probably will continue to do so through the work with #13.

Any votes on this? I'm a bit hesitant to merge.