### PR TITLE
Use Kubernetes native TCP readiness probe for kafka

### DIFF
--- a/50kafka.yml
+++ b/50kafka.yml
@@ -51,7 +51,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 9092
-          timeoutSeconds: 9
+          timeoutSeconds: 1
         volumeMounts:
         - name: config
           mountPath: /etc/kafka

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -51,7 +51,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 9092
-          timeoutSeconds: 10
+          timeoutSeconds: 9
         volumeMounts:
         - name: config
           mountPath: /etc/kafka

--- a/50kafka.yml
+++ b/50kafka.yml
@@ -49,11 +49,9 @@ spec:
             cpu: 100m
             memory: 512Mi
         readinessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - 'echo "" | nc -w 1 127.0.0.1 9092'
+          tcpSocket:
+            port: 9092
+          timeoutSeconds: 10
         volumeMounts:
         - name: config
           mountPath: /etc/kafka


### PR DESCRIPTION
As suggested in https://github.com/Yolean/kubernetes-kafka/issues/73.

Causes warnings in logs, as before.