### PR TITLE
Log collection through Filebeat daemonset

### DIFF
--- a/logs-streaming/00namespace.yml
+++ b/logs-streaming/00namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logs-kafka

--- a/logs-streaming/filebeat-config.yml
+++ b/logs-streaming/filebeat-config.yml
@@ -13,7 +13,7 @@ data:
         - /var/lib/docker/containers/*/*.log
       symlinks: true
       # reduce the risk for aggregation recursion: match pod names to exclude own's logs + test logs
-      exclude_files: ['^(.*\/)?logs-','^(.*\/)?test-']
+      exclude_files: ['^(.*\/)?logs-','^(.*\/)?filebeat-','^(.*\/)?test-']
 
     processors:
     - add_kubernetes_metadata:

--- a/logs-streaming/filebeat-config.yml
+++ b/logs-streaming/filebeat-config.yml
@@ -10,8 +10,7 @@ data:
     - type: log
       enabled: true
       paths:
-        - /var/log/containers/*.log
-      # Logs say a lot of https://github.com/elastic/beats/blob/v6.0.0-rc2/filebeat/prospector/log/prospector.go#L250
+        - /var/lib/docker/containers/*/*.log
       symlinks: true
       # reduce the risk for aggregation recursion: match pod names to exclude own's logs + test logs
       exclude_files: ['^(.*\/)?logs-','^(.*\/)?test-']
@@ -19,6 +18,7 @@ data:
     processors:
     - add_kubernetes_metadata:
         in_cluster: true
+        namespace: logs-kafka
 
     output.kafka:
       hosts: ["kafka-0.broker.kafka.svc.cluster.local:9092", "kafka-1.broker.kafka.svc.cluster.local:9092", "kafka-2.broker.kafka.svc.cluster.local:9092"]

--- a/logs-streaming/filebeat-config.yml
+++ b/logs-streaming/filebeat-config.yml
@@ -1,0 +1,33 @@
+kind: ConfigMap
+metadata:
+  name: filebeat-config
+  namespace: logs-kafka
+apiVersion: v1
+data:
+  filebeat.yml: |+
+
+    filebeat.prospectors:
+    - type: log
+      enabled: true
+      paths:
+        - /var/log/containers/*.log
+      symlinks: true
+      # reduce the risk for aggregation recursion: match pod names to exclude own's logs + test logs
+      exclude_files: ['^(.*\/)?logs-','^(.*\/)?test-']
+
+    processors:
+    - add_kubernetes_metadata:
+        in_cluster: true
+
+    output.kafka:
+      hosts: ["kafka-0.broker.kafka.svc.cluster.local:9092", "kafka-1.broker.kafka.svc.cluster.local:9092", "kafka-2.broker.kafka.svc.cluster.local:9092"]
+      topic: ${TOPIC}
+
+      partition.round_robin:
+        reachable_only: false
+
+      client_id: filebeat-kubernetes
+      version: 0.11.0.0
+      required_acks: 1
+      compression: gzip
+      max_message_bytes: 1000000

--- a/logs-streaming/filebeat-config.yml
+++ b/logs-streaming/filebeat-config.yml
@@ -11,6 +11,7 @@ data:
       enabled: true
       paths:
         - /var/log/containers/*.log
+      # Logs say a lot of https://github.com/elastic/beats/blob/v6.0.0-rc2/filebeat/prospector/log/prospector.go#L250
       symlinks: true
       # reduce the risk for aggregation recursion: match pod names to exclude own's logs + test logs
       exclude_files: ['^(.*\/)?logs-','^(.*\/)?test-']

--- a/logs-streaming/filebeat-logs-kube-kafka.yml
+++ b/logs-streaming/filebeat-logs-kube-kafka.yml
@@ -26,7 +26,7 @@ spec:
         - -c
         - /etc/filebeat/filebeat.yml
         - -d
-        - "service,beat,kubernetes"
+        - "service,beat"
         env:
         - name: TOPIC
           value: ops-kube-logs-filebeat-001

--- a/logs-streaming/filebeat-logs-kube-kafka.yml
+++ b/logs-streaming/filebeat-logs-kube-kafka.yml
@@ -36,7 +36,7 @@ spec:
             memory: 10Mi
           limits:
             cpu: 10m
-            memory: 30Mi
+            memory: 40Mi
         volumeMounts:
         - name: config
           mountPath: /etc/filebeat

--- a/logs-streaming/filebeat-logs-kube-kafka.yml
+++ b/logs-streaming/filebeat-logs-kube-kafka.yml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: filebeat
-        image: solsson/kafka-filebeat-kubernetes@sha256:79b40d81b892ffb3b917eb249f4b3050badf57fadffbdc35272060c9b377209e
+        image: solsson/kafka-filebeat-kubernetes@sha256:c2a68766e718d354b565b20f92baf0f50047b4bdf90a5055a20107a1131bee80
         command:
         - filebeat
         - -e

--- a/logs-streaming/filebeat-logs-kube-kafka.yml
+++ b/logs-streaming/filebeat-logs-kube-kafka.yml
@@ -26,7 +26,7 @@ spec:
         - -c
         - /etc/filebeat/filebeat.yml
         - -d
-        - "service,beat"
+        - "service,beat,kubernetes"
         env:
         - name: TOPIC
           value: ops-kube-logs-filebeat-001

--- a/logs-streaming/filebeat-logs-kube-kafka.yml
+++ b/logs-streaming/filebeat-logs-kube-kafka.yml
@@ -31,11 +31,12 @@ spec:
         - name: TOPIC
           value: ops-kube-logs-filebeat-001
         resources:
-          limits:
-            memory: 100Mi
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 2m
+            memory: 10Mi
+          limits:
+            cpu: 10m
+            memory: 20Mi
         volumeMounts:
         - name: config
           mountPath: /etc/filebeat

--- a/logs-streaming/filebeat-logs-kube-kafka.yml
+++ b/logs-streaming/filebeat-logs-kube-kafka.yml
@@ -36,7 +36,7 @@ spec:
             memory: 10Mi
           limits:
             cpu: 10m
-            memory: 20Mi
+            memory: 30Mi
         volumeMounts:
         - name: config
           mountPath: /etc/filebeat

--- a/logs-streaming/filebeat-logs-kube-kafka.yml
+++ b/logs-streaming/filebeat-logs-kube-kafka.yml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: filebeat-kube-kafka
+  namespace: logs-kafka
+spec:
+  selector:
+    matchLabels:
+      k8s-app: filebeat-kube-kafka
+      version: v1
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: filebeat-kube-kafka
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: filebeat
+        image: solsson/kafka-filebeat-kubernetes@sha256:79b40d81b892ffb3b917eb249f4b3050badf57fadffbdc35272060c9b377209e
+        command:
+        - filebeat
+        - -e
+        - -c
+        - /etc/filebeat/filebeat.yml
+        - -d
+        - "service,beat"
+        env:
+        - name: TOPIC
+          value: ops-kube-logs-filebeat-001
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - name: config
+          mountPath: /etc/filebeat
+          readOnly: true
+        - name: data
+          mountPath: /data
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: config
+        configMap:
+          name: filebeat-config
+      - name: data
+        hostPath:
+          path: /kubernets-filebeat-state
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/logs-streaming/filebeat-logs-kube-kafka.yml
+++ b/logs-streaming/filebeat-logs-kube-kafka.yml
@@ -16,6 +16,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      serviceAccountName: filebeat
       containers:
       - name: filebeat
         image: solsson/kafka-filebeat-kubernetes@sha256:c2a68766e718d354b565b20f92baf0f50047b4bdf90a5055a20107a1131bee80

--- a/logs-streaming/filebeat-logs-kube-kafka.yml
+++ b/logs-streaming/filebeat-logs-kube-kafka.yml
@@ -54,7 +54,7 @@ spec:
           name: filebeat-config
       - name: data
         hostPath:
-          path: /kubernets-filebeat-state
+          path: /tmp/kubernets-filebeat-state
       - name: varlog
         hostPath:
           path: /var/log

--- a/logs-streaming/rbac/filebeat.yml
+++ b/logs-streaming/rbac/filebeat.yml
@@ -7,11 +7,10 @@ metadata:
   annotations:
     manifest-origin: 'github.com/Yolean/kubernetes-kafka'
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: filebeat-sa-view
-  namespace: logs-kafka
+  name: logs-kafka-filebeat-sa-view
   annotations:
     manifest-origin: 'github.com/Yolean/kubernetes-kafka'
 subjects:

--- a/logs-streaming/rbac/filebeat.yml
+++ b/logs-streaming/rbac/filebeat.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: filebeat
+  namespace: logs-kafka
+  annotations:
+    manifest-origin: 'github.com/Yolean/kubernetes-kafka'
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: filebeat-sa-view
+  namespace: logs-kafka
+  annotations:
+    manifest-origin: 'github.com/Yolean/kubernetes-kafka'
+subjects:
+- kind: ServiceAccount
+  name: filebeat
+  namespace: logs-kafka
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io

--- a/logs-streaming/test/logs-filebeat.yml
+++ b/logs-streaming/test/logs-filebeat.yml
@@ -17,7 +17,7 @@ data:
 
     echo ""
     echo "{\"#---\":\"$(date -u --iso-8601='ns')\"}"
-    kafkacat -b $BOOTSTRAP -C -t $TOPIC -f '{"#topic":"%t","#partition":%p,"#offset":%o,"#key":"%k","=":%s}\n' -o -10 -e
+    kafkacat -b $BOOTSTRAP -C -t $TOPIC -f '{"#topic":"%t","#partition":%p,"#offset":%o,"#key":"%k","=":%s}\n' -o -10 -e -q
 
     exit 0
 

--- a/logs-streaming/test/logs-filebeat.yml
+++ b/logs-streaming/test/logs-filebeat.yml
@@ -1,0 +1,75 @@
+---
+kind: ConfigMap
+metadata:
+  name: logs-filebeat
+  namespace: test-kafka
+apiVersion: v1
+data:
+
+  setup.sh: |-
+    touch /tmp/testlog
+
+    tail -f /tmp/testlog
+
+  test.sh: |-
+    exec >> /tmp/testlog
+    exec 2>&1
+
+    echo ""
+    echo "{\"#---\":\"$(date -u --iso-8601='ns')\"}"
+    kafkacat -b $BOOTSTRAP -C -t $TOPIC -f '{"#topic":"%t","#partition":%p,"#offset":%o,"#key":"%k","=":%s}\n' -o -10 -e
+
+    exit 0
+
+  quit-on-nonzero-exit.sh: |-
+    exit 0
+
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: logs-filebeat
+  namespace: test-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      test-target: logs-streaming-filebeat
+      test-type: readiness
+  template:
+    metadata:
+      labels:
+        test-target: logs-streaming-filebeat
+        test-type: readiness
+    spec:
+      containers:
+      - name: testcase
+        image: solsson/kafkacat@sha256:ebebf47061300b14a4b4c2e1e4303ab29f65e4b95d34af1b14bb8f7ec6da7cef
+        env:
+        - name: BOOTSTRAP
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        - name: TOPIC
+          value: ops-kube-logs-filebeat-001
+        command:
+        - /bin/bash
+        - -e
+        - /test/setup.sh
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/test.sh
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/quit-on-nonzero-exit.sh
+        volumeMounts:
+        - name: config
+          mountPath: /test
+      volumes:
+      - name: config
+        configMap:
+          name: logs-filebeat

--- a/logs-streaming/topic-ops-kube-logs-filebeat.yml
+++ b/logs-streaming/topic-ops-kube-logs-filebeat.yml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: topic-ops-kube-logs-filebeat
+  namespace: logs-kafka
+spec:
+  template:
+    metadata:
+      labels:
+        app: topic-create
+        topic-id: ops-kube-logs-filebeat
+        topic-gen: "001"
+    spec:
+      containers:
+      - name: kafka
+        image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
+        command:
+        - ./bin/kafka-topics.sh
+        - --zookeeper
+        - zookeeper.kafka:2181
+        - --create
+        - --if-not-exists
+        - --topic
+        - ops-kube-logs-filebeat-001
+        - --partitions
+        - "1"
+        - --replication-factor
+        - "2"
+        - --config
+        - retention.ms=6912500000
+      restartPolicy: Never


### PR DESCRIPTION
Pending native kafka support for fluent-bit (https://github.com/fluent/fluent-bit/issues/94 or a go plugin) I'm evaluating filebeat which has kafka-support as an intermediate step for aggregation to ELK.

Candidate for merge to v3.0.0 (#84), with advantages over the `tail`-based solution:
 * Resumes at previous position
 * Discovers new files without restart
 * Adds (some) kubernetes metadata.
 * Every message contains source, compared to the delimeters approach from tail.
   - You'd can use `jq` to do like `kubectl logs -f` but for arbitrary filters on pods.

Sadly the `kubernetes` object lacks node name (zone name would be great too), a typical record having:
```json
    "offset": 8770457,
    "source": "/var/lib/docker/containers/671a46ea4b400c73424a9f438fa1102f83b4db2d9fe3e229f61824df953b5b26/671a46ea4b400c73424a9f438fa1102f83b4db2d9fe3e229f61824df953b5b26-json.log",
    "kubernetes": {
      "container": {
        "name": "testcase"
      },
      "labels": {
        "test-target": "logs-streaming-raw",
        "pod-template-hash": "1087956622",
        "test-type": "readiness"
      },
      "namespace": "test-kafka",
      "pod": {
        "name": "logs-raw-54dcf9bb66-898h5"
      }
    }
```
