### PR TITLE
Exposes JMX for brokers, and exemplify key cluster-level metric

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -43,11 +43,15 @@ spec:
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
+        - name: JMX_PORT
+          value: "5555"
         ports:
         - name: inside
           containerPort: 9092
         - name: outside
           containerPort: 9094
+        - name: jmx
+          containerPort: 5555
         command:
         - ./bin/kafka-server-start.sh
         - /etc/kafka/server.properties

--- a/monitoring/10-monitoring-config.yml
+++ b/monitoring/10-monitoring-config.yml
@@ -1,0 +1,14 @@
+kind: ConfigMap
+metadata:
+  name: monitoring-config
+  namespace: kafka
+apiVersion: v1
+data:
+  cluster-prometheus-jmx.yml: |+
+    #lowercaseOutputName: true
+    jmxUrl: service:jmx:rmi:///jndi/rmi://cluster-jmx:5555/jmxrmi
+    ssl: false
+    whitelistObjectNames:
+    - kafka.server:*
+    rules:
+    - pattern : kafka.server<type=ReplicaManager, name=(PartitionCount|UnderReplicatedPartitions)><>(Value|OneMinuteRate)

--- a/monitoring/10-monitoring-config.yml
+++ b/monitoring/10-monitoring-config.yml
@@ -11,4 +11,4 @@ data:
     whitelistObjectNames:
     - kafka.server:type=ReplicaManager,*
     rules:
-    - pattern: kafka.server<type=ReplicaManager, name=(.*)><>(.*)
+    - pattern: kafka.server<type=ReplicaManager, name=(.*)><>(Value|Count)

--- a/monitoring/10-monitoring-config.yml
+++ b/monitoring/10-monitoring-config.yml
@@ -11,4 +11,4 @@ data:
     whitelistObjectNames:
     - kafka.server:type=ReplicaManager,*
     rules:
-    - pattern: kafka.server<type=ReplicaManager, name=(.*)><>(Value|Count)
+    - pattern: kafka.server<type=ReplicaManager, name=(PartitionCount|UnderReplicatedPartitions)><>(Value|Count)

--- a/monitoring/10-monitoring-config.yml
+++ b/monitoring/10-monitoring-config.yml
@@ -9,6 +9,6 @@ data:
     jmxUrl: service:jmx:rmi:///jndi/rmi://cluster-jmx:5555/jmxrmi
     ssl: false
     whitelistObjectNames:
-    - kafka.server:*
+    - kafka.server:type=ReplicaManager,*
     rules:
-    - pattern : kafka.server<type=ReplicaManager, name=(PartitionCount|UnderReplicatedPartitions)><>(Value|OneMinuteRate)
+    - pattern: kafka.server<type=ReplicaManager, name=(.*)><>(.*)

--- a/monitoring/brokers-prometheus.yml
+++ b/monitoring/brokers-prometheus.yml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: brokers-prometheus
+  namespace: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: metrics
+      type: exporter
+      target: kafka-broker
+      level: cluster
+  template:
+    metadata:
+      labels:
+        role: metrics
+        type: exporter
+        target: kafka-broker
+        level: cluster
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "5556"
+    spec:
+      containers:
+      - name: exporter
+        image: solsson/kafka-prometheus-jmx-exporter@sha256:40a6ab24ccac0ed5acb8c02dccfbb1f5924fd97f46c0450e0245686c24138b53
+        command:
+        - java
+        - -jar
+        - jmx_prometheus_httpserver.jar
+        - "5556"
+        - /etc/kafka/cluster-prometheus-jmx.yml
+        ports:
+        - containerPort: 5556
+        resources:
+          requests:
+            cpu: 0m
+            memory: 40Mi
+          limits:
+            cpu: 100m
+            memory: 80Mi
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kafka
+      volumes:
+      - name: config
+        configMap:
+          name: monitoring-config

--- a/monitoring/cluster-jmx-service.yml
+++ b/monitoring/cluster-jmx-service.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-jmx
+  namespace: kafka
+spec:
+  ports:
+  - name: jmx
+    port: 5555
+  selector:
+    app: kafka


### PR DESCRIPTION
Already included in #49, but I would like to keep metrics opt-in while that PR adds a quite heavy container to the pod.

The exposed port can be utilized by kafka-manager (#83) - just tick the JMX box when adding a cluster - to see bytes in/out rates.