### PR TITLE
Disables RollingUpdate, i.e. reverts to pre-1.7 behavior

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -10,6 +10,8 @@ spec:
       app: kafka
   serviceName: "broker"
   replicas: 3
+  updateStrategy:
+    type: OnDelete
   template:
     metadata:
       labels:

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -11,6 +11,8 @@ spec:
       storage: persistent
   serviceName: "pzoo"
   replicas: 3
+  updateStrategy:
+    type: OnDelete
   template:
     metadata:
       labels:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -10,6 +10,8 @@ spec:
       storage: ephemeral
   serviceName: "zoo"
   replicas: 2
+  updateStrategy:
+    type: OnDelete
   template:
     metadata:
       labels:


### PR DESCRIPTION
#55 would revert this.

For discussions on this topic, see the [automation](https://github.com/Yolean/kubernetes-kafka/labels/automation) label.