### PR TITLE
Enable broker JMX_PORT 5555

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -43,11 +43,15 @@ spec:
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
+        - name: JMX_PORT
+          value: "5555"
         ports:
         - name: inside
           containerPort: 9092
         - name: outside
           containerPort: 9094
+        - name: jmx
+          containerPort: 5555
         command:
         - ./bin/kafka-server-start.sh
         - /etc/kafka/server.properties


### PR DESCRIPTION
This seems to be the common ground between different monitoring approaches, such as an export sidecar (#49) or additional tooling (#83).