### PR TITLE
Add linkedin/kafka-monitor

### DIFF
--- a/linkedin-kafka-monitor/kafka-monitor.yml
+++ b/linkedin-kafka-monitor/kafka-monitor.yml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: kafka-monitor
+  namespace: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-monitor
+  template:
+    metadata:
+      labels:
+        app: kafka-monitor
+    spec:
+      containers:
+      - name: kafka-monitor
+        image: solsson/kafka-monitor@sha256:12992f67379bc0850c977069d0283a9fb844e2f1b5530ca9525eea044b7f6b25
+        ports:
+        - name: http
+          containerPort: 8000
+        - name: metrics
+          containerPort: 8778


### PR DESCRIPTION
The best answer I've found to #80, on paper :) Remains to learn how to use it.

Adding the metrics label because the combination of readiness alerts for key health like under-replicated partitions (https://github.com/Yolean/kubernetes-kafka/pull/95/files#diff-f8da94a0c2daaa5e09e08330d1ed122a) and end-to-end testing like kafka-monitor may pay off better than monitoring internals.

In actual troubleshooting scenarios you'll probably still want to connect some JMX tool (allowed since #96) to really dig into the state of things.