### PR TITLE
Minor cleanups

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -4,7 +4,6 @@ metadata:
   name: kafka
   namespace: kafka
 spec:
-spec:
   selector:
     matchLabels:
       app: kafka

--- a/kafka/test/kafkacat.yml
+++ b/kafka/test/kafkacat.yml
@@ -115,7 +115,7 @@ spec:
         image: solsson/kafkacat@sha256:b32eedf936f3cde44cd164ddc77dfcf7565a8af4e357ff6de1abe4389ca530c9
         env:
         - name: BOOTSTRAP
-          value: kafka-0.broker.kafka.svc.cluster.local:9092
+          value: bootstrap.kafka:9092
         command:
         - /bin/bash
         - -cex
@@ -134,7 +134,7 @@ spec:
         image: solsson/kafkacat@sha256:b32eedf936f3cde44cd164ddc77dfcf7565a8af4e357ff6de1abe4389ca530c9
         env:
         - name: BOOTSTRAP
-          value: kafka-0.broker.kafka.svc.cluster.local:9092
+          value: bootstrap.kafka:9092
         command:
         - /bin/bash
         - -cex

--- a/kafka/test/produce-consume.yml
+++ b/kafka/test/produce-consume.yml
@@ -98,7 +98,7 @@ spec:
         image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
         env:
         - name: BOOTSTRAP
-          value: kafka-0.broker.kafka.svc.cluster.local:9092
+          value: bootstrap.kafka:9092
         command:
         - /bin/bash
         - -cex
@@ -117,7 +117,7 @@ spec:
         image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
         env:
         - name: BOOTSTRAP
-          value: kafka-0.broker.kafka.svc.cluster.local:9092
+          value: bootstrap.kafka:9092
         command:
         - /bin/bash
         - -cex
@@ -134,7 +134,7 @@ spec:
         image: solsson/kafkacat@sha256:ebebf47061300b14a4b4c2e1e4303ab29f65e4b95d34af1b14bb8f7ec6da7cef
         env:
         - name: BOOTSTRAP
-          value: kafka-0.broker.kafka.svc.cluster.local:9092
+          value: bootstrap.kafka:9092
         command:
         - /bin/bash
         - -e

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -4,7 +4,6 @@ metadata:
   name: pzoo
   namespace: kafka
 spec:
-spec:
   selector:
     matchLabels:
       app: zookeeper


### PR DESCRIPTION
I noticed a few thing that could be cleaned up, like the duplicate spec notations, and using the bootstrap service in the tests, since this is the new preferred usage.