### PR TITLE
Fix rbac to set useful labels on broker pods from init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ For clusters that enfoce [RBAC](https://kubernetes.io/docs/admin/authorization/r
 kubectl apply -f rbac-namespace-default/
 ```
 
-For example rack awareness can fail without this, `logs -c init-config` showing `Error from server (Forbidden): pods "kafka-0" is forbidden: User "system:serviceaccount:kafka:default" cannot get pods in the namespace "kafka": Unknown user "system:serviceaccount:kafka:default"`.
-
 ## Tests
 
 Tests are based on the [kube-test](https://github.com/Yolean/kube-test) concept.

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -23,7 +23,6 @@ data:
         sed -i "s/#init#broker.rack=#init#/broker.rack=$ZONE/" /etc/kafka/server.properties
       fi
 
-      # This requires additional RBAC, and won't be needed after https://github.com/kubernetes/kubernetes/pull/55329
       kubectl -n $POD_NAMESPACE label pod $POD_NAME kafka-broker-id=$KAFKA_BROKER_ID
 
       OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -11,6 +11,8 @@ data:
     KAFKA_BROKER_ID=${HOSTNAME##*-}
     sed -i "s/#init#broker.id=#init#/broker.id=$KAFKA_BROKER_ID/" /etc/kafka/server.properties
 
+    LABELS="kafka-broker-id=$KAFKA_BROKER_ID"
+
     hash kubectl 2>/dev/null || {
       sed -i "s/#init#broker.rack=#init#/#init#broker.rack=# kubectl not found in path/" /etc/kafka/server.properties
     } && {
@@ -21,10 +23,8 @@ data:
         sed -i "s/#init#broker.rack=#init#/#init#broker.rack=# zone label not found for node $NODE_NAME/" /etc/kafka/server.properties
       else
         sed -i "s/#init#broker.rack=#init#/broker.rack=$ZONE/" /etc/kafka/server.properties
-        kubectl -n $POD_NAMESPACE label pod $POD_NAME kafka-broker-rack=$ZONE
+        LABELS="$LABELS kafka-broker-rack=$ZONE"
       fi
-
-      kubectl -n $POD_NAMESPACE label pod $POD_NAME kafka-broker-id=$KAFKA_BROKER_ID
 
       OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
       if [ $? -ne 0 ]; then
@@ -32,8 +32,11 @@ data:
       else
         OUTSIDE_PORT=3240${KAFKA_BROKER_ID}
         sed -i "s|#init#advertised.listeners=OUTSIDE://#init#|advertised.listeners=OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|" /etc/kafka/server.properties
-        kubectl -n $POD_NAMESPACE label pod $POD_NAME kafka-listener-outside-host=$OUTSIDE_HOST
-        kubectl -n $POD_NAMESPACE label pod $POD_NAME kafka-listener-outside-port=$OUTSIDE_PORT
+        LABELS="$LABELS kafka-listener-outside-host=$OUTSIDE_HOST kafka-listener-outside-port=$OUTSIDE_PORT"
+      fi
+
+      if [ ! -z "$LABELS" ]; then
+        kubectl -n $POD_NAMESPACE label pod $POD_NAME $LABELS || echo "Failed to label $POD_NAMESPACE.$POD_NAME - RBAC issue?"
       fi
     }
 

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -21,6 +21,7 @@ data:
         sed -i "s/#init#broker.rack=#init#/#init#broker.rack=# zone label not found for node $NODE_NAME/" /etc/kafka/server.properties
       else
         sed -i "s/#init#broker.rack=#init#/broker.rack=$ZONE/" /etc/kafka/server.properties
+        kubectl -n $POD_NAMESPACE label pod $POD_NAME kafka-broker-rack=$ZONE
       fi
 
       kubectl -n $POD_NAMESPACE label pod $POD_NAME kafka-broker-id=$KAFKA_BROKER_ID
@@ -29,8 +30,10 @@ data:
       if [ $? -ne 0 ]; then
         echo "Outside (i.e. cluster-external access) host lookup command failed"
       else
-        OUTSIDE_HOST=${OUTSIDE_HOST}:3240${KAFKA_BROKER_ID}
-        sed -i "s|#init#advertised.listeners=OUTSIDE://#init#|advertised.listeners=OUTSIDE://${OUTSIDE_HOST}|" /etc/kafka/server.properties
+        OUTSIDE_PORT=3240${KAFKA_BROKER_ID}
+        sed -i "s|#init#advertised.listeners=OUTSIDE://#init#|advertised.listeners=OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|" /etc/kafka/server.properties
+        kubectl -n $POD_NAMESPACE label pod $POD_NAME kafka-listener-outside-host=$OUTSIDE_HOST
+        kubectl -n $POD_NAMESPACE label pod $POD_NAME kafka-listener-outside-port=$OUTSIDE_PORT
       fi
     }
 

--- a/rbac-namespace-default/pod-labler.yml
+++ b/rbac-namespace-default/pod-labler.yml
@@ -2,7 +2,6 @@
 #
 # $ kubectl -n kafka logs kafka-2 -c init-config
 # ...
-# + kubectl -n kafka label pod kafka-2 kafka-broker-id=2
 # Error from server (Forbidden): pods "kafka-2" is forbidden: User "system:serviceaccount:kafka:default" cannot get pods in the namespace "kafka": Unknown user "system:serviceaccount:kafka:default"
 #
 ---

--- a/rbac-namespace-default/pod-labler.yml
+++ b/rbac-namespace-default/pod-labler.yml
@@ -1,0 +1,41 @@
+# To see if init containers need RBAC:
+#
+# $ kubectl exec kafka-0 -- cat /etc/kafka/server.properties | grep broker.rack
+# #init#broker.rack=# zone lookup failed, see -c init-config logs
+# $ kubectl logs -c init-config kafka-0
+# ++ kubectl get node some-node '-o=go-template={{index .metadata.labels "failure-domain.beta.kubernetes.io/zone"}}'
+# Error from server (Forbidden): User "system:serviceaccount:kafka:default" cannot get nodes at the cluster scope.: "Unknown user \"system:serviceaccount:kafka:default\""
+#
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-labler
+  namespace: kafka
+  labels:
+    origin: github.com_Yolean_kubernetes-kafka
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - update
+  - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kafka-pod-labler
+  namespace: kafka
+  labels:
+    origin: github.com_Yolean_kubernetes-kafka
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-labler
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kafka

--- a/rbac-namespace-default/pod-labler.yml
+++ b/rbac-namespace-default/pod-labler.yml
@@ -1,10 +1,9 @@
 # To see if init containers need RBAC:
 #
-# $ kubectl exec kafka-0 -- cat /etc/kafka/server.properties | grep broker.rack
-# #init#broker.rack=# zone lookup failed, see -c init-config logs
-# $ kubectl logs -c init-config kafka-0
-# ++ kubectl get node some-node '-o=go-template={{index .metadata.labels "failure-domain.beta.kubernetes.io/zone"}}'
-# Error from server (Forbidden): User "system:serviceaccount:kafka:default" cannot get nodes at the cluster scope.: "Unknown user \"system:serviceaccount:kafka:default\""
+# $ kubectl -n kafka logs kafka-2 -c init-config
+# ...
+# + kubectl -n kafka label pod kafka-2 kafka-broker-id=2
+# Error from server (Forbidden): pods "kafka-2" is forbidden: User "system:serviceaccount:kafka:default" cannot get pods in the namespace "kafka": Unknown user "system:serviceaccount:kafka:default"
 #
 ---
 kind: Role


### PR DESCRIPTION
I [thought](https://github.com/Yolean/kubernetes-kafka/commit/096e3bdfba31d2918520011886a6a0d1f1b08c84) https://github.com/kubernetes/kubernetes/pull/55329 would make such labels obsolete, but seeing that k8s 1.9 sets for example `statefulset.kubernetes.io/pod-name: kafka-0` I think they complement each other.
  
Moreover #78 depends on the `kafka-broker-id` for the `./outsite-services/` per-broker service.