### PR TITLE
Scale to run on two nodes

### DIFF
--- a/avro-tools/test/rest-curl.yml
+++ b/avro-tools/test/rest-curl.yml
@@ -114,7 +114,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -58,9 +58,9 @@ data:
     # the brokers.
     num.partitions=1
 
-    default.replication.factor=3
+    default.replication.factor=2
 
-    min.insync.replicas=2
+    min.insync.replicas=1
 
     auto.create.topics.enable=true
 

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -115,9 +115,9 @@ data:
     ############################# Internal Topic Settings  #############################
     # The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
     # For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
-    #offsets.topic.replication.factor=1
-    #transaction.state.log.replication.factor=1
-    #transaction.state.log.min.isr=1
+    offsets.topic.replication.factor=2
+    transaction.state.log.replication.factor=2
+    transaction.state.log.min.isr=1
 
     ############################# Log Flush Policy #############################
 

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -8,7 +8,7 @@ spec:
     matchLabels:
       app: kafka
   serviceName: "broker"
-  replicas: 3
+  replicas: 2
   updateStrategy:
     type: OnDelete
   template:

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -42,7 +42,7 @@ spec:
           mountPath: /etc/kafka
       containers:
       - name: broker
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties

--- a/kafka/test/kafkacat.yml
+++ b/kafka/test/kafkacat.yml
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/kafka/test/produce-consume.yml
+++ b/kafka/test/produce-consume.yml
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper
@@ -95,7 +95,7 @@ spec:
     spec:
       containers:
       - name: producer
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         env:
         - name: BOOTSTRAP
           value: bootstrap.kafka:9092
@@ -114,7 +114,7 @@ spec:
         - name: shared
           mountPath: /shared
       - name: consumer
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         env:
         - name: BOOTSTRAP
           value: bootstrap.kafka:9092

--- a/maintenance/preferred-replica-election-job.yml
+++ b/maintenance/preferred-replica-election-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         command:
         - ./bin/kafka-preferred-replica-election.sh
         - --zookeeper

--- a/maintenance/reassign-paritions-job.yml
+++ b/maintenance/reassign-paritions-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         env:
         - name: ZOOKEEPER
           value: zookeeper.kafka:2181

--- a/maintenance/replication-factor-increase-job.yml
+++ b/maintenance/replication-factor-increase-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         env:
         - name: ZOOKEEPER
           value: zookeeper.kafka:2181

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -23,9 +23,7 @@ data:
     syncLimit=2
     server.1=pzoo-0.pzoo:2888:3888:participant
     server.2=pzoo-1.pzoo:2888:3888:participant
-    server.3=pzoo-2.pzoo:2888:3888:participant
     server.4=zoo-0.zoo:2888:3888:participant
-    server.5=zoo-1.zoo:2888:3888:participant
 
   log4j.properties: |-
     log4j.rootLogger=INFO, stdout

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -9,7 +9,7 @@ spec:
       app: zookeeper
       storage: persistent
   serviceName: "pzoo"
-  replicas: 3
+  replicas: 2
   updateStrategy:
     type: OnDelete
   template:

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -33,7 +33,7 @@ spec:
           mountPath: /var/lib/zookeeper/data
       containers:
       - name: zookeeper
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -9,7 +9,7 @@ spec:
       app: zookeeper
       storage: ephemeral
   serviceName: "zoo"
-  replicas: 2
+  replicas: 1
   updateStrategy:
     type: OnDelete
   template:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -36,7 +36,7 @@ spec:
           mountPath: /var/lib/zookeeper/data
       containers:
       - name: zookeeper
-        image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789
+        image: solsson/kafka:2.0.0@sha256:8bc5ccb5a63fdfb977c1e207292b72b34370d2c9fe023bdc0f8ce0d8e0da1670
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties


### PR DESCRIPTION
For a bare metal backup cluster experiment, based on https://github.com/Yolean/kubeadm-vagrant.

Will be interesting to keep responsive at single node downtime, with respect to zookeeper quorums in particular. See https://github.com/Yolean/kubernetes-kafka/issues/26#issuecomment-350754982 and https://github.com/Yolean/kubernetes-kafka/issues/70#issuecomment-333949099 for history on that.

Will rebase #44 on this one, as it's scaled down further. Would be interesting to experiment with #112 here.