### PR TITLE
Heapster with Kafka as Metrics Sink

### DIFF
--- a/heapster/heapster-rbac.yaml
+++ b/heapster/heapster-rbac.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: heapster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:heapster
+subjects:
+- kind: ServiceAccount
+  name: heapster
+  namespace: kube-system

--- a/heapster/heapster.yaml
+++ b/heapster/heapster.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: heapster
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: heapster
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: heapster
+    spec:
+      serviceAccountName: heapster
+      containers:
+      - name: heapster
+        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - /heapster
+        - --source=kubernetes:https://kubernetes.default
+        - --sink=influxdb:http://monitoring-influxdb.kube-system.svc:8086
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    task: monitoring
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are NOT using this as an addon, you should comment out this line.
+    kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: Heapster
+  name: heapster
+  namespace: kube-system
+spec:
+  ports:
+  - port: 80
+    targetPort: 8082
+  selector:
+    k8s-app: heapster

--- a/heapster/heapster.yaml
+++ b/heapster/heapster.yaml
@@ -25,7 +25,7 @@ spec:
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
-        - --sink="kafka:?brokers=bootstrap.kafka:9092"
+        - --sink=kafka:?brokers=bootstrap.kafka:9092
 ---
 apiVersion: v1
 kind: Service

--- a/heapster/heapster.yaml
+++ b/heapster/heapster.yaml
@@ -25,7 +25,7 @@ spec:
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
-        - --sink=influxdb:http://monitoring-influxdb.kube-system.svc:8086
+        - --sink="kafka:?brokers=bootstrap.kafka:9092"
 ---
 apiVersion: v1
 kind: Service

--- a/heapster/heapster.yaml
+++ b/heapster/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        image: k8s.gcr.io/heapster-amd64:v1.5.0
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
Used with https://github.com/Yolean/kubeadm-vagrant to support `kubectl top nodes` and `kubectl top pods --all-namespaces`.