### PR TITLE
Improve robustness of events-kube test

### DIFF
--- a/events-kube/events-kube-kafka.yml
+++ b/events-kube/events-kube-kafka.yml
@@ -38,6 +38,7 @@ spec:
           curl
           -f
           -s
+          -S
           --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt
           --header "Authorization: Bearer $(cat /run/secrets/kubernetes.io/serviceaccount/token)"
           https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/watch/events

--- a/events-kube/test/events-topic.yml
+++ b/events-kube/test/events-topic.yml
@@ -49,12 +49,6 @@ spec:
       labels:
         test-target: events-topic
         test-type: readiness
-        # for example:
-        # readonly - can be used in production
-        # isolated - read/write but in a manner that does not affect other services
-        # load - unsuitable for production because it uses significant resources
-        # chaos - unsuitable for production because it injects failure modes
-        #test-use:
     spec:
       containers:
       - name: testcase

--- a/events-kube/test/events-topic.yml
+++ b/events-kube/test/events-topic.yml
@@ -72,8 +72,8 @@ spec:
             - /bin/bash
             - -e
             - /test/test.sh
-          initialDelaySeconds: 10
-          periodSeconds: 60
+          initialDelaySeconds: 60
+          periodSeconds: 3600
         livenessProbe:
           exec:
             command:

--- a/events-kube/test/events-topic.yml
+++ b/events-kube/test/events-topic.yml
@@ -72,8 +72,8 @@ spec:
             - /bin/bash
             - -e
             - /test/test.sh
-          initialDelaySeconds: 60
-          periodSeconds: 3600
+          initialDelaySeconds: 10
+          periodSeconds: 60
         livenessProbe:
           exec:
             command:

--- a/events-kube/test/events-topic.yml
+++ b/events-kube/test/events-topic.yml
@@ -1,3 +1,5 @@
+# Note that this test is scaled to zero
+# because it will only stay healthy when there are cluster events, at least 1 per periodSeconds
 ---
 kind: ConfigMap
 metadata:
@@ -35,7 +37,7 @@ metadata:
   name: events-topic
   namespace: test-kafka
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
Partially address #109, with curl errors displayed (in brief) and WIP less unreadiness for the test when cluster is idle. 