### PR TITLE
Adding storage class files for AKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Zookeeper at `zookeeper.kafka.svc.cluster.local:2181`.
 
 For Minikube run `kubectl apply -f configure/minikube-storageclass-broker.yml; kubectl apply -f configure/minikube-storageclass-zookeeper.yml`.
 
-There's a similar setup for GKE, `configure/gke-*`. You might want to tweak it before creating.
+There's a similar setup for AKS under `configure/aks-*` and for GKE under `configure/gke-*`. You might want to tweak it before creating.
 
 ## Start Zookeeper
 

--- a/configure/aks-storageclass-broker-managed.yml
+++ b/configure/aks-storageclass-broker-managed.yml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: kafka-broker
+provisioner: kubernetes.io/azure-disk
+reclaimPolicy: Retain
+parameters:
+  kind: "Managed"
+  storageaccounttype: Premium_LRS

--- a/configure/aks-storageclass-zookeeper-managed.yml
+++ b/configure/aks-storageclass-zookeeper-managed.yml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: kafka-zookeeper
+provisioner: kubernetes.io/azure-disk
+reclaimPolicy: Retain
+parameters:
+  kind: "Managed"
+  storageaccounttype: Premium_LRS


### PR DESCRIPTION
* Added two `yml` files under `configure` for broker and zookeeper storage classes based on AKS (Azure Kubernetes Service)
* Updated README.md to mention the new option