### PR TITLE
Add variations on basic test cases, to investigate replication

### DIFF
--- a/kafka/test/kafkacat_bootstrapbrokers.yml
+++ b/kafka/test/kafkacat_bootstrapbrokers.yml
@@ -1,0 +1,158 @@
+---
+kind: ConfigMap
+metadata:
+  name: kafkacat-bootstrapbrokers
+  namespace: test-kafka
+apiVersion: v1
+data:
+
+  setup.sh: |-
+    touch /tmp/testlog
+
+    tail -f /tmp/testlog
+
+  test.sh: |-
+    exec >> /tmp/testlog
+    exec 2>&1
+
+    PC_WAIT=.2
+    MAX_AGE=5
+
+    UNIQUE="${HOSTNAME}@$(date -u -Ins)"
+
+    echo "${UNIQUE: -41:5}:Test $UNIQUE" >> /shared/produce.tmp
+    sleep $PC_WAIT
+    LAST=$(tail -n 1 /shared/consumed.tmp)
+    [ -z "$LAST" ] && echo "Nothing consumed" && exit 1
+
+    LAST_TS=$(echo $LAST | awk -F';' '{print $1}')
+    [ -z "$LAST_TS" ] && echo "Failed to get timestamp for message: $LAST" && exit 1
+    LAST_MSG=$(echo $LAST | awk -F';' '{print $4}')
+    NOW=$(date -u +%s%3N)
+    DIFF_S=$((($NOW - $LAST_TS)/1000))
+    DIFF_MS=$((($NOW - $LAST_TS)%1000))
+    #echo "$NOW ($(date +%FT%H:%M:%S.%3N)):"
+    #echo "$LAST_TS"
+
+    if [ $DIFF_S -gt $MAX_AGE ]; then
+      echo "Last message is $DIFF_S.$DIFF_MS old:"
+      echo "$LAST_MSG"
+      exit 10
+    fi
+
+    if [[ "$LAST_MSG" != *"$UNIQUE" ]]; then
+      echo "Last message (at $LAST_TS) isn't from this test run ($UNIQUE):"
+      echo "$LAST_MSG"
+      exit 11
+    fi
+
+    # get info about this message
+    kafkacat -Q -b $BOOTSTRAP -t test-kafkacat-bootstrapbrokers:0:$LAST_TS \
+      -X socket.timeout.ms=600 -X session.timeout.ms=300 -X request.timeout.ms=50 -X metadata.request.timeout.ms=600
+    [ $? -eq 0 ] || echo "At $(date +%FT%H:%M:%S.%3N) bootstrap broker(s) might be down"
+    # but don't fail the test; producer and consumer should keep going if there are other brokers
+
+    # We haven't asserted that the consumer works, so we'll just have to assume that it will exit if it fails
+
+    exit 0
+
+  quit-on-nonzero-exit.sh: |-
+    exec >> /tmp/testlog
+    exec 2>&1
+
+    exit 0
+---
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  name: kafkacat-bootstrapbrokers
+  namespace: test-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      test-target: kafka-client-kafkacat-bootstrapbrokers
+      test-type: readiness
+  template:
+    metadata:
+      labels:
+        test-target: kafka-client-kafkacat-bootstrapbrokers
+        test-type: readiness
+        # for example:
+        # readonly - can be used in production
+        # isolated - read/write but in a manner that does not affect other services
+        # load - unsuitable for production because it uses significant resources
+        # chaos - unsuitable for production because it injects failure modes
+        #test-use:
+    spec:
+      containers:
+      - name: producer
+        image: solsson/kafkacat@sha256:b32eedf936f3cde44cd164ddc77dfcf7565a8af4e357ff6de1abe4389ca530c9
+        env:
+        - name: BOOTSTRAP
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        command:
+        - /bin/bash
+        - -cex
+        - >
+          echo "--- start $HOSTNAME $(date --iso-8601='ns' -u) ---" >> /shared/produce.tmp
+          ;
+          tail -f /shared/produce.tmp |
+          kafkacat -P -b $BOOTSTRAP -t test-kafkacat-bootstrapbrokers -v -T -d broker -K ':'
+          ;
+        volumeMounts:
+        - name: config
+          mountPath: /test
+        - name: shared
+          mountPath: /shared
+      - name: consumer
+        image: solsson/kafkacat@sha256:b32eedf936f3cde44cd164ddc77dfcf7565a8af4e357ff6de1abe4389ca530c9
+        env:
+        - name: BOOTSTRAP
+          value: bootstrap.kafka:9092
+        command:
+        - /bin/bash
+        - -cex
+        - >
+          kafkacat -C -b $BOOTSTRAP -t test-kafkacat-bootstrapbrokers -o -1 -f '%T;%k:%p;%o;%s\n' -u -d broker |
+          tee /shared/consumed.tmp
+          ;
+        volumeMounts:
+        - name: config
+          mountPath: /test
+        - name: shared
+          mountPath: /shared
+      - name: testcase
+        image: solsson/kafkacat@sha256:b32eedf936f3cde44cd164ddc77dfcf7565a8af4e357ff6de1abe4389ca530c9
+        env:
+        - name: BOOTSTRAP
+          value: bootstrap.kafka:9092
+        command:
+        - /bin/bash
+        - -e
+        - /test/setup.sh
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/test.sh
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/quit-on-nonzero-exit.sh
+        volumeMounts:
+        - name: config
+          mountPath: /test
+        - name: shared
+          mountPath: /shared
+      volumes:
+      - name: config
+        configMap:
+          name: kafkacat-bootstrapbrokers
+      - name: shared
+        emptyDir: {}

--- a/kafka/test/kafkacat_bootstrapbrokers.yml
+++ b/kafka/test/kafkacat_bootstrapbrokers.yml
@@ -109,7 +109,7 @@ spec:
         image: solsson/kafkacat@sha256:b32eedf936f3cde44cd164ddc77dfcf7565a8af4e357ff6de1abe4389ca530c9
         env:
         - name: BOOTSTRAP
-          value: bootstrap.kafka:9092
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
         command:
         - /bin/bash
         - -cex
@@ -126,7 +126,7 @@ spec:
         image: solsson/kafkacat@sha256:b32eedf936f3cde44cd164ddc77dfcf7565a8af4e357ff6de1abe4389ca530c9
         env:
         - name: BOOTSTRAP
-          value: bootstrap.kafka:9092
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
         command:
         - /bin/bash
         - -e

--- a/kafka/test/produce-consume_3acks.yml
+++ b/kafka/test/produce-consume_3acks.yml
@@ -1,0 +1,163 @@
+---
+kind: ConfigMap
+metadata:
+  name: produce-consume-3acks
+  namespace: test-kafka
+apiVersion: v1
+data:
+
+  setup.sh: |-
+    touch /tmp/testlog
+
+    tail -f /tmp/testlog
+
+  test.sh: |-
+    exec >> /tmp/testlog
+    exec 2>&1
+
+    # As low as in kafkacat based test didn't work, but this value can likely be squeezed
+    PC_WAIT=2.0
+
+    UNIQUE="${HOSTNAME}@$(date -u -Ins)"
+
+    echo "Test $UNIQUE" >> /shared/produce.tmp
+    sleep $PC_WAIT
+    LAST=$(tail -n 1 /shared/consumed.tmp)
+    [ -z "$LAST" ] && echo "Nothing consumed yet" && exit 1
+
+    # Haven't found how to get message timestamp in console-consumer, see kafkacat based test instead
+    LAST_MSG=$LAST
+
+    if [[ "$LAST_MSG" != *"$UNIQUE" ]]; then
+      echo "Last message (at $(date +%FT%T)) isn't from this test run ($UNIQUE):"
+      echo "$LAST_MSG"
+      exit 11
+    fi
+
+    echo "OK ($LAST_MSG at $(date +%FT%T))"
+    # We haven't asserted that the consumer works, so we'll just have to assume that it will exit if it fails
+
+    exit 0
+
+  quit-on-nonzero-exit.sh: |-
+    exec >> /tmp/testlog
+    exec 2>&1
+
+    exit 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: topic-test-produce-consume-3acks
+  namespace: test-kafka
+spec:
+  template:
+    spec:
+      containers:
+      - name: topic-create
+        image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
+        command:
+        - ./bin/kafka-topics.sh
+        - --zookeeper
+        -   zookeeper.kafka.svc.cluster.local:2181
+        - --alter
+        - --topic
+        -   test-produce-consume-3acks
+        - --config
+        -   min.insync.replicas=3
+      restartPolicy: Never
+---
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  name: produce-consume-3acks
+  namespace: test-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      test-target: kafka-client-console-3acks
+      test-type: readiness
+  template:
+    metadata:
+      labels:
+        test-target: kafka-client-console-3acks
+        test-type: readiness
+        # for example:
+        # readonly - can be used in production
+        # isolated - read/write but in a manner that does not affect other services
+        # load - unsuitable for production because it uses significant resources
+        # chaos - unsuitable for production because it injects failure modes
+        #test-use:
+    spec:
+      containers:
+      - name: producer
+        image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
+        env:
+        - name: BOOTSTRAP
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        command:
+        - /bin/bash
+        - -cex
+        - >
+          echo "--- start $HOSTNAME $(date --iso-8601='ns' -u) ---" >> /shared/produce.tmp
+          ;
+          tail -f /shared/produce.tmp |
+          ./bin/kafka-console-producer.sh --broker-list $BOOTSTRAP --topic test-produce-consume-3acks --request-required-acks all --request-timeout-ms 500
+          ;
+        volumeMounts:
+        - name: config
+          mountPath: /test
+        - name: shared
+          mountPath: /shared
+      - name: consumer
+        image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
+        env:
+        - name: BOOTSTRAP
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        command:
+        - /bin/bash
+        - -cex
+        - >
+          ./bin/kafka-console-consumer.sh --bootstrap-server $BOOTSTRAP --topic test-produce-consume-3acks --csv-reporter-enabled --metrics-dir /kafka-metrics |
+          tee /shared/consumed.tmp
+          ;
+        volumeMounts:
+        - name: config
+          mountPath: /test
+        - name: shared
+          mountPath: /shared
+      - name: testcase
+        image: solsson/kafkacat@sha256:ebebf47061300b14a4b4c2e1e4303ab29f65e4b95d34af1b14bb8f7ec6da7cef
+        env:
+        - name: BOOTSTRAP
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        command:
+        - /bin/bash
+        - -e
+        - /test/setup.sh
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/test.sh
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/quit-on-nonzero-exit.sh
+        volumeMounts:
+        - name: config
+          mountPath: /test
+        - name: shared
+          mountPath: /shared
+      volumes:
+      - name: config
+        configMap:
+          name: produce-consume-3acks
+      - name: shared
+        emptyDir: {}

--- a/kafka/test/produce-consume_bootstrapbrokers.yml
+++ b/kafka/test/produce-consume_bootstrapbrokers.yml
@@ -1,0 +1,141 @@
+---
+kind: ConfigMap
+metadata:
+  name: produce-consume-bootstrapbrokers
+  namespace: test-kafka
+apiVersion: v1
+data:
+
+  setup.sh: |-
+    touch /tmp/testlog
+
+    tail -f /tmp/testlog
+
+  test.sh: |-
+    exec >> /tmp/testlog
+    exec 2>&1
+
+    # As low as in kafkacat based test didn't work, but this value can likely be squeezed
+    PC_WAIT=2.0
+
+    UNIQUE="${HOSTNAME}@$(date -u -Ins)"
+
+    echo "Test $UNIQUE" >> /shared/produce.tmp
+    sleep $PC_WAIT
+    LAST=$(tail -n 1 /shared/consumed.tmp)
+    [ -z "$LAST" ] && echo "Nothing consumed yet" && exit 1
+
+    # Haven't found how to get message timestamp in console-consumer, see kafkacat based test instead
+    LAST_MSG=$LAST
+
+    if [[ "$LAST_MSG" != *"$UNIQUE" ]]; then
+      echo "Last message (at $(date +%FT%T)) isn't from this test run ($UNIQUE):"
+      echo "$LAST_MSG"
+      exit 11
+    fi
+
+    echo "OK ($LAST_MSG at $(date +%FT%T))"
+    # We haven't asserted that the consumer works, so we'll just have to assume that it will exit if it fails
+
+    exit 0
+
+  quit-on-nonzero-exit.sh: |-
+    exec >> /tmp/testlog
+    exec 2>&1
+
+    exit 0
+---
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  name: produce-consume-bootstrapbrokers
+  namespace: test-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      test-target: kafka-client-console-bootstrapbrokers
+      test-type: readiness
+  template:
+    metadata:
+      labels:
+        test-target: kafka-client-console-bootstrapbrokers
+        test-type: readiness
+        # for example:
+        # readonly - can be used in production
+        # isolated - read/write but in a manner that does not affect other services
+        # load - unsuitable for production because it uses significant resources
+        # chaos - unsuitable for production because it injects failure modes
+        #test-use:
+    spec:
+      containers:
+      - name: producer
+        image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
+        env:
+        - name: BOOTSTRAP
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        command:
+        - /bin/bash
+        - -cex
+        - >
+          echo "--- start $HOSTNAME $(date --iso-8601='ns' -u) ---" >> /shared/produce.tmp
+          ;
+          tail -f /shared/produce.tmp |
+          ./bin/kafka-console-producer.sh --broker-list $BOOTSTRAP --topic test-produce-consume-bootstrapbrokers
+          ;
+        volumeMounts:
+        - name: config
+          mountPath: /test
+        - name: shared
+          mountPath: /shared
+      - name: consumer
+        image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
+        env:
+        - name: BOOTSTRAP
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        command:
+        - /bin/bash
+        - -cex
+        - >
+          ./bin/kafka-console-consumer.sh --bootstrap-server $BOOTSTRAP --topic test-produce-consume-bootstrapbrokers |
+          tee /shared/consumed.tmp
+          ;
+        volumeMounts:
+        - name: config
+          mountPath: /test
+        - name: shared
+          mountPath: /shared
+      - name: testcase
+        image: solsson/kafkacat@sha256:ebebf47061300b14a4b4c2e1e4303ab29f65e4b95d34af1b14bb8f7ec6da7cef
+        env:
+        - name: BOOTSTRAP
+          value: kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        command:
+        - /bin/bash
+        - -e
+        - /test/setup.sh
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/test.sh
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/quit-on-nonzero-exit.sh
+        volumeMounts:
+        - name: config
+          mountPath: /test
+        - name: shared
+          mountPath: /shared
+      volumes:
+      - name: config
+        configMap:
+          name: produce-consume-bootstrapbrokers
+      - name: shared
+        emptyDir: {}


### PR DESCRIPTION
Probably no merge, as this is for learning and for troubleshooting #116 and #132.

The "3acks" test is to try to exemplify producer behavior when insufficient acks are received. If kafka is scaled from 3 to 2, the original "produce-consume" test (#79) stays ready while the new "produce-consume-3acks goes Unready.

```
org.apache.kafka.common.errors.NotEnoughReplicasException: Messages are rejected since there are fewer in-sync replicas than required.
[2018-01-22 19:46:08,562] WARN [Producer clientId=console-producer] Got error produce response with correlation id 369 on topic-partition test-produce-consume-3acks-0, retrying (2 attempts left). Error: NOT_ENOUGH_REPLICAS (org.apache.kafka.clients.producer.internals.Sender)
[2018-01-22 19:46:08,664] WARN [Producer clientId=console-producer] Got error produce response with correlation id 370 on topic-partition test-produce-consume-3acks-0, retrying (1 attempts left). Error: NOT_ENOUGH_REPLICAS (org.apache.kafka.clients.producer.internals.Sender)
[2018-01-22 19:46:08,766] WARN [Producer clientId=console-producer] Got error produce response with correlation id 371 on topic-partition test-produce-consume-3acks-0, retrying (0 attempts left). Error: NOT_ENOUGH_REPLICAS (org.apache.kafka.clients.producer.internals.Sender)
[2018-01-22 19:46:08,867] ERROR Error when sending message to topic test-produce-consume-3acks with key: null, value: 68 bytes with error: (org.apache.kafka.clients.producer.internals.ErrorLoggingCallback)
org.apache.kafka.common.errors.NotEnoughReplicasException: Messages are rejected since there are fewer in-sync replicas than required.
[2018-01-22 19:46:18,556] WARN [Producer clientId=console-producer] Got error produce response with correlation id 373 on topic-partition test-produce-consume-3acks-0, retrying (2 attempts left). Error: NOT_ENOUGH_REPLICAS (org.apache.kafka.clients.producer.internals.Sender)
[2018-01-22 19:46:19,158] WARN [Producer clientId=console-producer] Got error produce response with correlation id 374 on topic-partition test-produce-consume-3acks-0, retrying (1 attempts left). Error: NETWORK_EXCEPTION (org.apache.kafka.clients.producer.internals.Sender)
```

... and when kafka is scaled back it silently resumes and the test goes back to Ready.

The two "-bootstrapbrokers" tests haven't given any clues for #132. They too get the occasional "Receive failed: Disconnected".