### PR TITLE
Set internal replication factors to match default and min.insync.replicas

### DIFF
--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -114,8 +114,8 @@ data:
     # The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
     # For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
     #offsets.topic.replication.factor=1
-    transaction.state.log.replication.factor=1
-    transaction.state.log.min.isr=1
+    #transaction.state.log.replication.factor=1
+    #transaction.state.log.min.isr=1
 
     ############################# Log Flush Policy #############################
 

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -57,6 +57,7 @@ data:
     num.partitions=1
 
     default.replication.factor=3
+    offsets.topic.replication.factor=3
 
     min.insync.replicas=2
 

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -57,7 +57,6 @@ data:
     num.partitions=1
 
     default.replication.factor=3
-    offsets.topic.replication.factor=3
 
     min.insync.replicas=2
 
@@ -114,7 +113,7 @@ data:
     ############################# Internal Topic Settings  #############################
     # The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
     # For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
-    offsets.topic.replication.factor=1
+    #offsets.topic.replication.factor=1
     transaction.state.log.replication.factor=1
     transaction.state.log.min.isr=1
 

--- a/kafka/test/kafkacat.yml
+++ b/kafka/test/kafkacat.yml
@@ -91,6 +91,7 @@ metadata:
   name: kafkacat
   namespace: test-kafka
 spec:
+  # Note that this test sets a consumer group, but asserts assume that the tests gets its own messages
   replicas: 1
   selector:
     matchLabels:
@@ -133,11 +134,13 @@ spec:
         env:
         - name: BOOTSTRAP
           value: bootstrap.kafka:9092
+        - name: CONSUMER_GROUP_ID
+          value: test-kafkacat-group
         command:
         - /bin/bash
         - -cex
         - >
-          kafkacat -C -b $BOOTSTRAP -t test-kafkacat -o -1 -f '%T;%k:%p;%o;%s\n' -u -d broker |
+          kafkacat -b $BOOTSTRAP -G $CONSUMER_GROUP_ID test-kafkacat -o -1 -f '%T;%k:%p;%o;%s\n' -u -d broker |
           tee /shared/consumed.tmp
           ;
         volumeMounts:

--- a/kafka/test/kafkacat.yml
+++ b/kafka/test/kafkacat.yml
@@ -102,12 +102,6 @@ spec:
       labels:
         test-target: kafka-client-kafkacat
         test-type: readiness
-        # for example:
-        # readonly - can be used in production
-        # isolated - read/write but in a manner that does not affect other services
-        # load - unsuitable for production because it uses significant resources
-        # chaos - unsuitable for production because it injects failure modes
-        #test-use:
     spec:
       containers:
       - name: producer

--- a/kafka/test/kafkacat.yml
+++ b/kafka/test/kafkacat.yml
@@ -83,8 +83,6 @@ spec:
         -   test-kafkacat
         - --partitions
         -   "1"
-        - --replication-factor
-        -   "2"
       restartPolicy: Never
 ---
 apiVersion: apps/v1beta2

--- a/kafka/test/produce-consume.yml
+++ b/kafka/test/produce-consume.yml
@@ -66,8 +66,6 @@ spec:
         -   test-produce-consume
         - --partitions
         -   "1"
-        - --replication-factor
-        -   "2"
       restartPolicy: Never
 ---
 apiVersion: apps/v1beta2

--- a/kafka/test/replication-config.yml
+++ b/kafka/test/replication-config.yml
@@ -1,0 +1,98 @@
+# https://github.com/Yolean/kubernetes-kafka/pull/140
+---
+kind: ConfigMap
+metadata:
+  name: replication-config
+  namespace: test-kafka
+apiVersion: v1
+data:
+
+  setup.sh: |-
+    touch /tmp/testlog
+
+    tail -f /tmp/testlog
+
+  test.sh: |-
+    exec >> /tmp/testlog
+    exec 2>&1
+    set -e
+
+    kafkacat -L -b $BOOTSTRAP > /tmp/metadata
+    BROKERS=$(cat /tmp/metadata | grep -E ' [0-9]+ brokers:' | awk '{print $1}')
+    if (( $BROKERS == 1 )); then
+      echo "Only one broker; no need to check for >1 replication config."
+      exit 0
+    fi
+
+    WITH_TWO_OR_MORE=$(cat /tmp/metadata | grep -E ' replicas: [0-9]+,[0-9]+' | wc -l)
+    WITH_ONE=$(cat /tmp/metadata | grep -E ' replicas: [0-9]+, ' | wc -l)
+    if (( $WITH_TWO_OR_MORE == 0 )); then
+      echo "No partitions have >1 replica, so this is probably normal."
+      exit 0
+    fi
+
+    if (( $WITH_ONE > $MAX_SINGLE_REPLICA_PARTITIONS )); then
+      echo "$(date --iso-8601='ns') There are $WITH_ONE partitions with only one replica. Alerts for under-replicated partitions won't catch that."
+      exit 10
+    fi
+
+    echo "$(date --iso-8601='ns') $WITH_ONE partitions have one replica and WITH_TWO_OR_MORE have more"
+    exit 0
+
+  quit-on-nonzero-exit.sh: |-
+    exec >> /tmp/testlog
+    exec 2>&1
+
+    exit 0
+---
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  name: replication-config
+  namespace: test-kafka
+spec:
+  # Note that this test sets a consumer group, but asserts assume that the tests gets its own messages
+  replicas: 1
+  selector:
+    matchLabels:
+      test-target: kafka-replication-config
+      test-type: readiness
+  template:
+    metadata:
+      labels:
+        test-target: kafka-replication-config
+        test-type: readiness
+    spec:
+      containers:
+      - name: testcase
+        image: solsson/kafkacat@sha256:b32eedf936f3cde44cd164ddc77dfcf7565a8af4e357ff6de1abe4389ca530c9
+        env:
+        - name: BOOTSTRAP
+          value: bootstrap.kafka:9092
+        - name: MAX_SINGLE_REPLICA_PARTITIONS
+          value: "0"
+        command:
+        - /bin/bash
+        - -e
+        - /test/setup.sh
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/test.sh
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -e
+            - /test/quit-on-nonzero-exit.sh
+        volumeMounts:
+        - name: config
+          mountPath: /test
+      volumes:
+      - name: config
+        configMap:
+          name: replication-config

--- a/yahoo-kafka-manager/kafka-manager.yml
+++ b/yahoo-kafka-manager/kafka-manager.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: kafka-manager
-        image: solsson/kafka-manager@sha256:e07b5c50b02c761b3471ebb62ede88afc0625e325fe428316e32fec7f227ff9b
+        image: solsson/kafka-manager@sha256:5db7d54cdb642ec5a92f37a869fdcf2aa479b2552e900b2d2b83b38a1806c2de
         ports:
         - containerPort: 80
         env:


### PR DESCRIPTION
Based on @shrinandj's find in #139.

As explained in https://github.com/Yolean/kubernetes-kafka/issues/116#issuecomment-359548701 we'd like to keep min.insync.replicas=2.

What's odd is that the default, according to [docs](https://kafka.apache.org/documentation/#brokerconfigs), is 3. Also I guess this change won't affect a running kafka cluster.

This property isn't mentioned in https://kafka.apache.org/documentation/#prodconfig.
There was a change in [0.11](https://kafka.apache.org/documentation/#upgrade_1100_notable): "The offsets.topic.replication.factor broker config is now enforced upon auto topic creation."

This PR quite possibly needs

- [ ] A repro case.
- [x] A #95 style job to fix existing clusters.
   - https://github.com/Yolean/kubernetes-kafka/pull/95/commits/49649e19bb7775165b6f5409211e05840f5c50ef
- [x] A similar fix to `transaction.state.log.replication.factor`.
- [x] ~~A similar fix to `config.storage.replication.factor`.
   - Defaulted to 3 already, used for Kafka Connect only?
- [x] ~~A similar fix to `status.storage.replication.factor`.
   - Defaulted to 3 already, used for Kafka Connect only?
- [x] ~~A similar fix to `replication.factor`.~~
   - Seems to be a Kafka Streams client property only.