### PR TITLE
cp configmap elements over to config volume as configmap vol is RO

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you begin to rely on this kafka setup we recommend you fork, for example to e
 
 | tag   | k8s ≥ | highlights |
 | ----- | ------ | ---------- |
+| master | 1.9.4 | Required for read-only ConfigMaps, k8s 1.9.4+ |
 | v3.1  | 1.8    | The painstaking path to `min.insync.replicas`=2 |
 | v3.0  | 1.8    | [Outside access](#78), [modern manifests](#84), [bootstrap.kafka](#52) |
 | v2.1  | 1.5    | Kafka 1.0, the init script concept |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To quote [@arthurk](https://github.com/Yolean/kubernetes-kafka/issues/82#issueco
 
 > thanks for creating and maintaining this Kubernetes files, they're up-to-date (unlike the kubernetes contrib files, don't require helm and work great!
 
-## Gettings started
+## Getting started
 
 We suggest you `apply -f` manifests in the following order:
  * You choice of storage classes from [./configure](./configure/)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you begin to rely on this kafka setup we recommend you fork, for example to e
 
 | tag   | k8s ≥ | highlights |
 | ----- | ------ | ---------- |
-| master | 1.9.4 | Required for read-only ConfigMaps, k8s 1.9.4+ |
+| master | 1.9.4, 1.8.9, 1.7.14 | Required for read-only ConfigMaps [#162](https://github.com/Yolean/kubernetes-kafka/issues/162) [#163](https://github.com/Yolean/kubernetes-kafka/pull/163) [k8s #58720](https://github.com/kubernetes/kubernetes/pull/58720) |
 | v3.1  | 1.8    | The painstaking path to `min.insync.replicas`=2 |
 | v3.0  | 1.8    | [Outside access](#78), [modern manifests](#84), [bootstrap.kafka](#52) |
 | v2.1  | 1.5    | Kafka 1.0, the init script concept |

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -9,6 +9,7 @@ data:
     set -x
 
     KAFKA_BROKER_ID=${HOSTNAME##*-}
+    cp -Lur /etc/kafka-configmap/* /etc/kafka/
     sed -i "s/#init#broker.id=#init#/broker.id=$KAFKA_BROKER_ID/" /etc/kafka/server.properties
 
     LABELS="kafka-broker-id=$KAFKA_BROKER_ID"

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -34,8 +34,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        command: ['/bin/bash', '/etc/kafka/init.sh']
+        command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
         volumeMounts:
+        - name: configmap
+          mountPath: /etc/kafka-configmap
         - name: config
           mountPath: /etc/kafka
       containers:
@@ -70,9 +72,11 @@ spec:
         - name: data
           mountPath: /var/lib/kafka/data
       volumes:
-      - name: config
+      - name: configmap
         configMap:
           name: broker-config
+      - name: config
+        emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
       - name: init-config
-        image: solsson/kafka-initutils@sha256:d9dcee0210b58dd53c8dd328a3929e97eb33ef0c624e95e2ce832024df888a5d
+        image: solsson/kafka-initutils@sha256:18bf01c2c756b550103a99b3c14f741acccea106072cd37155c6d24be4edd6e2
         env:
         - name: NODE_NAME
           valueFrom:

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
       - name: init-config
-        image: solsson/kafka-initutils@sha256:c98d7fb5e9365eab391a5dcd4230fc6e72caf929c60f29ff091e3b0215124713
+        image: solsson/kafka-initutils@sha256:d9dcee0210b58dd53c8dd328a3929e97eb33ef0c624e95e2ce832024df888a5d
         env:
         - name: NODE_NAME
           valueFrom:

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -11,6 +11,7 @@ data:
     [ -z "$ID_OFFSET" ] && ID_OFFSET=1
     export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + $ID_OFFSET))
     echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid
+    cp -Lur /etc/kafka-configmap/* /etc/kafka/
     sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" /etc/kafka/zookeeper.properties
 
   zookeeper.properties: |-

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -23,8 +23,10 @@ spec:
       initContainers:
       - name: init-config
         image: solsson/kafka:1.0.1@sha256:1a4689d49d6274ac59b9b740f51b0408e1c90a9b66d16ad114ee9f7193bab111
-        command: ['/bin/bash', '/etc/kafka/init.sh']
+        command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
         volumeMounts:
+        - name: configmap
+          mountPath: /etc/kafka-configmap
         - name: config
           mountPath: /etc/kafka
         - name: data
@@ -61,9 +63,11 @@ spec:
         - name: data
           mountPath: /var/lib/zookeeper/data
       volumes:
-      - name: config
+      - name: configmap
         configMap:
           name: zookeeper-config
+      - name: config
+        emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 10
       initContainers:
       - name: init-config
-        image: solsson/kafka:1.0.1@sha256:1a4689d49d6274ac59b9b740f51b0408e1c90a9b66d16ad114ee9f7193bab111
+        image: solsson/kafka-initutils@sha256:d9dcee0210b58dd53c8dd328a3929e97eb33ef0c624e95e2ce832024df888a5d
         command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
         volumeMounts:
         - name: configmap

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 10
       initContainers:
       - name: init-config
-        image: solsson/kafka-initutils@sha256:d9dcee0210b58dd53c8dd328a3929e97eb33ef0c624e95e2ce832024df888a5d
+        image: solsson/kafka-initutils@sha256:18bf01c2c756b550103a99b3c14f741acccea106072cd37155c6d24be4edd6e2
         command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
         volumeMounts:
         - name: configmap

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -23,11 +23,13 @@ spec:
       initContainers:
       - name: init-config
         image: solsson/kafka:1.0.1@sha256:1a4689d49d6274ac59b9b740f51b0408e1c90a9b66d16ad114ee9f7193bab111
-        command: ['/bin/bash', '/etc/kafka/init.sh']
+        command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
         env:
         - name: ID_OFFSET
           value: "4"
         volumeMounts:
+        - name: configmap
+          mountPath: /etc/kafka-configmap
         - name: config
           mountPath: /etc/kafka
         - name: data
@@ -64,8 +66,10 @@ spec:
         - name: data
           mountPath: /var/lib/zookeeper/data
       volumes:
-      - name: config
+      - name: configmap
         configMap:
           name: zookeeper-config
+      - name: config
+        emptyDir: {}
       - name: data
         emptyDir: {}

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 10
       initContainers:
       - name: init-config
-        image: solsson/kafka-initutils@sha256:d9dcee0210b58dd53c8dd328a3929e97eb33ef0c624e95e2ce832024df888a5d
+        image: solsson/kafka-initutils@sha256:18bf01c2c756b550103a99b3c14f741acccea106072cd37155c6d24be4edd6e2
         command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
         env:
         - name: ID_OFFSET

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 10
       initContainers:
       - name: init-config
-        image: solsson/kafka:1.0.1@sha256:1a4689d49d6274ac59b9b740f51b0408e1c90a9b66d16ad114ee9f7193bab111
+        image: solsson/kafka-initutils@sha256:d9dcee0210b58dd53c8dd328a3929e97eb33ef0c624e95e2ce832024df888a5d
         command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
         env:
         - name: ID_OFFSET


### PR DESCRIPTION
I ran into an issue when deploying this onto our Tectonic kubernetes cluster. It turns out that the ConfigMap volumes are mounted read-only. I'm unsure if this is standard kubernetes behavior, but minikube does not do the same thing; it allows modification of the configmap files. Glancing at kubernetes code, it appears it *should* be mounted read-only.

So to fix this, I made a new emptyDir volume for where the config should go and then make the init containers copy the configmap files before they modify them. 