### PR TITLE
Increase default offset retention to 7 days

### DIFF
--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -144,6 +144,9 @@ data:
     # A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
     # from the end of the log.
 
+    # https://cwiki.apache.org/confluence/display/KAFKA/KIP-186%3A+Increase+offsets+retention+default+to+7+days
+    offsets.retention.minutes=10080
+
     # The minimum age of a log file to be eligible for deletion due to age
     log.retention.hours=-1
 


### PR DESCRIPTION
Our use case is to handle topics that are not produced to during weekends, while we might do maintenance work that restarts all consumers in a group.

https://issues.apache.org/jira/browse/KAFKA-3806 says "Offset retention should be always greater than log retention." but that's mathematically difficult in our case :)

I found https://www.ctheu.com/2017/08/07/looking-at-kafka-s-consumers-offsets/ worthwhile.

