### PR TITLE
Kafka 1.1.0

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -42,7 +42,7 @@ spec:
           mountPath: /etc/kafka
       containers:
       - name: broker
-        image: solsson/kafka:1.0.1@sha256:1a4689d49d6274ac59b9b740f51b0408e1c90a9b66d16ad114ee9f7193bab111
+        image: solsson/kafka:1.1@sha256:ba863ca7dc28563930584e37f93d57c2cbf3f46b1c1fa104fe8af7bcc0c31df4
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties


### PR DESCRIPTION
Reverted the upgrade in #171.

With support for dynamic config stored in zookeeper it should be possible to do #78 through the CLI instead of init script changes. That in turn makes it likely that no one needs to edit the init script, in which case it can move to a regular entrypoint in a docker build such as #155. In particular if we can find a way to do #41 without kubectl access.