### PR TITLE
Adds mirrormaker example for GKE clusters

### DIFF
--- a/mirrormaker/mirrormaker.yml
+++ b/mirrormaker/mirrormaker.yml
@@ -44,7 +44,7 @@ spec:
         - >
           echo "bootstrap.servers=$SOURCE_BOOTSTRAP" >  ./config/consumer.properties;
           echo "group.id=$GROUP_ID"                  >> ./config/consumer.properties;
-          echo "auto.offset.reset=earliest"          >> ./config/consumer.properties;
+          echo "auto.offset.reset=none"              >> ./config/consumer.properties;
           echo "bootstrap.servers=$TARGET_BOOTSTRAP" >  ./config/producer.properties;
           echo "log4j.logger.org.apache.kafka.clients.Metadata=DEBUG"                              >> ./config/tools-log4j.properties;
           echo "log4j.logger.org.apache.kafka.clients.consumer.internals.AbstractCoordinator=INFO" >> ./config/tools-log4j.properties;

--- a/mirrormaker/mirrormaker.yml
+++ b/mirrormaker/mirrormaker.yml
@@ -35,7 +35,7 @@ spec:
         - name: SOURCE_BOOTSTRAP
           value: mirror-from.kafka:32400,mirror-from.kafka:32401,mirror-from.kafka:32402
         - name: WHITELIST
-          value: .*yolean.*yolean.*operations.*
+          value: .*yolean.*operations.*
         - name: GROUP_ID
           value: mirror-to-4
         command:

--- a/mirrormaker/mirrormaker.yml
+++ b/mirrormaker/mirrormaker.yml
@@ -22,7 +22,31 @@ spec:
       containers:
       - name: kafka
         image: solsson/kafka:1.1@sha256:ba863ca7dc28563930584e37f93d57c2cbf3f46b1c1fa104fe8af7bcc0c31df4
+        resources:
+          requests:
+            cpu: 0m
+            memory: 80Mi
+          limits:
+            cpu: 20m
+            memory: 200Mi
+        env:
+        - name: TARGET_BOOTSTRAP
+          value: bootstrap.kafka:9092
+        - name: SOURCE_BOOTSTRAP
+          value: mirror-from.kafka:32400,mirror-from.kafka:32401,mirror-from.kafka:32402
+        - name: WHITELIST
+          value: .*yolean.*yolean.*operations.*
+        - name: GROUP_ID
+          value: mirror-to-4
         command:
-        - tail
-        - -f
-        - /dev/null
+        - bash
+        - -cex
+        - >
+          echo "bootstrap.servers=$SOURCE_BOOTSTRAP" >  ./config/consumer.properties;
+          echo "group.id=$GROUP_ID"                  >> ./config/consumer.properties;
+          echo "auto.offset.reset=earliest"          >> ./config/consumer.properties;
+          echo "bootstrap.servers=$TARGET_BOOTSTRAP" >  ./config/producer.properties;
+          echo "log4j.logger.org.apache.kafka.clients.Metadata=DEBUG"                              >> ./config/tools-log4j.properties;
+          echo "log4j.logger.org.apache.kafka.clients.consumer.internals.AbstractCoordinator=INFO" >> ./config/tools-log4j.properties;
+          echo "log4j.logger.org.apache.kafka.clients.NetworkClient=INFO"                          >> ./config/tools-log4j.properties;
+          ./bin/kafka-mirror-maker.sh --consumer.config ./config/consumer.properties --producer.config ./config/producer.properties --whitelist "$WHITELIST"

--- a/mirrormaker/mirrormaker.yml
+++ b/mirrormaker/mirrormaker.yml
@@ -45,6 +45,7 @@ spec:
           echo "bootstrap.servers=$SOURCE_BOOTSTRAP" >  ./config/consumer.properties;
           echo "group.id=$GROUP_ID"                  >> ./config/consumer.properties;
           echo "auto.offset.reset=none"              >> ./config/consumer.properties;
+          echo "partition.assignment.strategy=org.apache.kafka.clients.consumer.RoundRobinAssignor" >> ./config/consumer.properties;
           echo "bootstrap.servers=$TARGET_BOOTSTRAP" >  ./config/producer.properties;
           echo "log4j.logger.org.apache.kafka.clients.Metadata=DEBUG"                              >> ./config/tools-log4j.properties;
           echo "log4j.logger.org.apache.kafka.clients.consumer.internals.AbstractCoordinator=INFO" >> ./config/tools-log4j.properties;

--- a/mirrormaker/mirrormaker.yml
+++ b/mirrormaker/mirrormaker.yml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mirror-a
+  namespace: kafka
+  labels:
+    app: mirrormaker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mirrormaker
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: mirrormaker
+    spec:
+      containers:
+      - name: kafka
+        image: solsson/kafka:1.1@sha256:ba863ca7dc28563930584e37f93d57c2cbf3f46b1c1fa104fe8af7bcc0c31df4
+        command:
+        - tail
+        - -f
+        - /dev/null

--- a/mirrormaker/source-endpoints.yml
+++ b/mirrormaker/source-endpoints.yml
@@ -1,0 +1,32 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: mirror-from
+  namespace: kafka
+spec:
+  ports:
+  - name: outside-0
+    port: 32400
+  - name: outside-1
+    port: 32401
+  - name: outside-2
+    port: 32402
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: mirror-from
+  namespace: kafka
+subsets:
+- addresses:
+  # source cluster: kubectl -n kafka get pods -l app=kafka -o yaml | grep outside
+  - ip: 10.132.0.13
+  - ip: 10.132.0.9
+  - ip: 10.132.0.10
+  ports:
+  - name: outside-0
+    port: 32400
+  - name: outside-1
+    port: 32401
+  - name: outside-2
+    port: 32402


### PR DESCRIPTION
Tested with the default #78 in GKE.

A couple of manifest values need customization:
 * `WHITELIST`
 * `GROUP_ID`
 * `ip:`s in source-endpoints.yml

Keeping resource limits low in order to reduce performance implications.
