### PR TITLE
Rest proxy updates: zookeeper configuration and service name

### DIFF
--- a/avro-tools/avro-tools-config.yml
+++ b/avro-tools/avro-tools-config.yml
@@ -20,6 +20,7 @@ data:
     listeners=http://0.0.0.0:80
     bootstrap.servers=PLAINTEXT://bootstrap.kafka:9092
     schema.registry.url=http://avro-schemas.kafka:80
+    zookeeper.connect=zookeeper.kafka:2181
 
     # https://github.com/Landoop/kafka-topics-ui#common-issues
     access.control.allow.methods=GET,POST,PUT,DELETE,OPTIONS

--- a/avro-tools/test/70rest-test1.yml
+++ b/avro-tools/test/70rest-test1.yml
@@ -14,7 +14,7 @@ spec:
         image: solsson/curl@sha256:523319afd39573746e8f5a7c98d4a6cd4b8cbec18b41eb30c8baa13ede120ce3
         env:
         - name: REST
-          value: http://rest.kafka.svc.cluster.local
+          value: http://avro-rest.kafka.svc.cluster.local
         - name: TOPIC
           value: test1
         command:


### PR DESCRIPTION
Adds zookeeper to the rest proxies config to solve a timeout error ("unable to connect to zookeeper").
Updates the service name used for testing the proxy.

----

[Awesome project and community, btw!!]