### PR TITLE
OUTSIDE_HOST is now resolved with ExternalIP address

### DIFF
--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -27,7 +27,7 @@ data:
         LABELS="$LABELS kafka-broker-rack=$ZONE"
       fi
 
-      OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+      OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
       if [ $? -ne 0 ]; then
         echo "Outside (i.e. cluster-external access) host lookup command failed"
       else


### PR DESCRIPTION
I believe we need to use ExternalIP (instead of InternalIP) to configure advertised.listerners so that apps outside the Kubernetes cluster can access the brokers.    This was tested/verified in GKE and now I can use my various tools in my PC to interact with Kafka brokers.  (Brokers/Zookeepers still communicate with each other using InternalIP) 

Below is relevant information from GKE.    Please note that minikube does NOT report ExternalIP,  so it will not work for minikube.  (For that to work, I had to hardcode HOUTSIDE_HOST but that should be a separate PR)
``` 
> kubectl get node gke-my-awesome-cluster-abcdf123456 -o json
{
    "apiVersion": "v1",
    "kind": "Node",
    "metadata": {
        "annotations": {
            "node.alpha.kubernetes.io/ttl": "0",
            "volumes.kubernetes.io/controller-managed-attach-detach": "true"
        },
        "creationTimestamp": "2018-05-31T22:50:12Z",
        "labels": {
            "beta.kubernetes.io/arch": "amd64",
            "beta.kubernetes.io/fluentd-ds-ready": "true",
            "beta.kubernetes.io/instance-type": "n1-highmem-2",
            "beta.kubernetes.io/os": "linux",
            "cloud.google.com/gke-nodepool": "default-pool",
            "failure-domain.beta.kubernetes.io/region": "us-central1",
            "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
            "kubernetes.io/hostname": "gke-my-awesome-cluster-abcdf123456"
        },
        "name": "gke-my-awesome-cluster-abcdf123456",
        "resourceVersion": "3189957",
        "selfLink": "/api/v1/nodes/gke-my-awesome-cluster-abcdf123456",
        "uid": "bla-bla-bla"
    },
    "spec": {
        "externalID": "1234567890",
        "podCIDR": "10.0.0.0/24",
        "providerID": "gce://my-cool-project/us-central1-a/gke-my-awesome-cluster-abcdf123456"
    },
    "status": {
        "addresses": [
            {
                "address": "xx.xxx.x.xx",
                "type": "InternalIP"
            },
            {
                "address": "xxx.xxx.xxx.xxx",
                "type": "ExternalIP"
            },
            {
                "address": "gke-my-awesome-cluster-abcdf123456",
                "type": "Hostname"
            }
        ],
```