### PR TITLE
Example Docker Registry notification setup

### DIFF
--- a/docker-registry/namespace.yml
+++ b/docker-registry/namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: registry

--- a/docker-registry/registry-config.yml
+++ b/docker-registry/registry-config.yml
@@ -27,7 +27,8 @@ data:
       endpoints:
       - name: kafka-through-pixy
         disabled: false
-        url: http://pixy.kafka/topics/ops.docker-registry.json/messages
+        #url: http://pixy.kafka/topics/ops.docker-registry.json/messages
+        url: http://requestbin.requestbin/1kk9jgk1
         headers:
           Content-Type: [application/json]
         # we should probably reduce timeout and backof once this is up and running

--- a/docker-registry/registry-config.yml
+++ b/docker-registry/registry-config.yml
@@ -1,0 +1,36 @@
+kind: ConfigMap
+metadata:
+  name: registry-config
+  namespace: registry
+apiVersion: v1
+data:
+  config.yml: |-
+    version: 0.1
+    log:
+      fields:
+        service: registry
+    storage:
+      cache:
+        blobdescriptor: inmemory
+      filesystem:
+        rootdirectory: /var/lib/registry
+    http:
+      addr: :5000
+      headers:
+        X-Content-Type-Options: [nosniff]
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
+    notifications:
+      endpoints:
+      - name: kafka-through-pixy
+        disabled: false
+        url: http://pixy.kafka/topics/ops.docker-registry.json/messages
+        headers:
+          Content-Type: [application/json]
+        # we should probably reduce timeout and backof once this is up and running
+        timeout: 3000ms
+        threshold: 3
+        backoff: 5s

--- a/docker-registry/registry-config.yml
+++ b/docker-registry/registry-config.yml
@@ -27,10 +27,7 @@ data:
       endpoints:
       - name: kafka-through-pixy
         disabled: false
-        #url: http://pixy.kafka/topics/ops.docker-registry.json/messages
-        url: http://requestbin.requestbin/1kk9jgk1
-        headers:
-          Content-Type: [application/json]
+        url: http://pixy.kafka/topics/ops.docker-registry.json/messages
         # we should probably reduce timeout and backof once this is up and running
         timeout: 3000ms
         threshold: 3

--- a/docker-registry/registry.yml
+++ b/docker-registry/registry.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: v2
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: docker-v2
-        image: registry:2.6.2@sha256:d837de65fd9bdb81d74055f1dc9cc9154ad5d8d5328f42f57f273000c402c76d
+        image: registry:2.6.2@sha256:672d519d7fd7bbc7a448d17956ebeefe225d5eb27509d8dc5ce67ecb4a0bce54
         resources:
           requests:
             cpu: 1m
@@ -34,8 +34,13 @@ spec:
           # On GKE this enables pull from 127.0.0.1:5000 but not from localhost
           hostPort: 5000
         env:
-        - name: REGISTRY_HTTP_ADDR
-          value: :5000
         # Required when we run 2 or more replicas
         - name: REGISTRY_HTTP_SECRET
           value: veryrandom
+        volumeMounts:
+        - name: etc-registry
+          mountPath: /etc/docker/registry
+      volumes:
+      - name: etc-registry
+        configMap:
+          name: registry-config

--- a/docker-registry/registry.yml
+++ b/docker-registry/registry.yml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: v2
+  namespace: registry
+spec:
+  selector:
+    matchLabels:
+      app: registry
+      k8s-app: kube-registry
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        app: registry
+        k8s-app: kube-registry
+        kubernetes.io/cluster-service: "true"
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: docker-v2
+        image: registry:2.6.2@sha256:d837de65fd9bdb81d74055f1dc9cc9154ad5d8d5328f42f57f273000c402c76d
+        resources:
+          requests:
+            cpu: 1m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 5000
+          name: registry
+          protocol: TCP
+          # On GKE this enables pull from 127.0.0.1:5000 but not from localhost
+          hostPort: 5000
+        env:
+        - name: REGISTRY_HTTP_ADDR
+          value: :5000
+        # Required when we run 2 or more replicas
+        - name: REGISTRY_HTTP_SECRET
+          value: veryrandom

--- a/pixy/pixy.yml
+++ b/pixy/pixy.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: pixy
-        image: mailgun/kafka-pixy:0.15.0@sha256:088210d53945a0db5f93921ceff3a79c012449b7845baebe8898452741764e7c
+        image: solsson/kafka-pixy:webhook-produce-logging@sha256:e2818d5a33df7c44afda57ce4c4f862bfd19b515eae45f2eda0f93c9e5dcfc2f
         ports:
         - containerPort: 80
         command:


### PR DESCRIPTION
Produces events to kafka such as

```json
{
   "events": [
      {
         "id": "02db6a4f-1b85-43a9-b5f4-35830eafdd3b",
         "timestamp": "2018-08-14T15:30:44.588042658Z",
         "action": "push",
         "target": {
            "mediaType": "application/octet-stream",
            "size": 4933978,
            "digest": "sha256:9ffbeef4b3a3d71c6da3fbd226ad0edddfe32059da63a0ed5c8757bdd5f3d1d2",
            "length": 4933978,
            "repository": "pixy",
            "url": "http://localhost:5000/v2/pixy/blobs/sha256:9ffbeef4b3a3d71c6da3fbd226ad0edddfe32059da63a0ed5c8757bdd5f3d1d2"
         },
         "request": {
            "id": "8f8655f8-e5fe-410a-a265-e70c46dc4b35",
            "addr": "172.17.0.1:46702",
            "host": "localhost:5000",
            "method": "PUT",
            "useragent": "docker/17.12.1-ce go/go1.9.4 git-commit/7390fc6 kernel/4.15.0 os/linux arch/amd64 UpstreamClient(Docker-Client/18.06.0-ce \\(darwin\\))"
         },
         "actor": {},
         "source": {
            "addr": "v2-vpxvk:5000",
            "instanceID": "a6893be0-efbc-4081-b705-210339d30574"
         }
      }
   ]
}
```

But note the patched Pixy, https://github.com/solsson/kafka-pixy/pull/1