### PR TITLE
Topics now get 12 partitions by default

### DIFF
--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -56,7 +56,7 @@ data:
     # The default number of log partitions per topic. More partitions allow greater
     # parallelism for consumption, but this will also result in more files across
     # the brokers.
-    num.partitions=1
+    num.partitions=12
 
     default.replication.factor=3
 


### PR DESCRIPTION
The number 12 was chosen to support an even load.
Counts of 2, 3, 4 and 6 are reasonable for both replicas and consumer group members.
At the same time we didn't want a high default number because the sample config file
mentions "more files across the brokers".

The reason for doing this change is that clients should not assume ordering guarantees unless designed for.

With #221 we won't use this default a lot, but maybe in the "not designed for" cases.