### PR TITLE
Crash loop intentionally if any command in an init script fails

### DIFF
--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -6,6 +6,7 @@ apiVersion: v1
 data:
   init.sh: |-
     #!/bin/bash
+    set -e
     set -x
     cp /etc/kafka-configmap/log4j.properties /etc/kafka/
 

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -6,6 +6,7 @@ apiVersion: v1
 data:
   init.sh: |-
     #!/bin/bash
+    set -e
     set -x
 
     [ -z "$ID_OFFSET" ] && ID_OFFSET=1


### PR DESCRIPTION
Fixes #168, possibly avoiding unexpected states for example at transient kubectl errors