### PR TITLE
Switch to Parallel start for Kafka and Zookeeper

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -11,6 +11,7 @@ spec:
   replicas: 3
   updateStrategy:
     type: RollingUpdate
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -12,6 +12,7 @@ spec:
   replicas: 3
   updateStrategy:
     type: RollingUpdate
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -12,6 +12,7 @@ spec:
   replicas: 2
   updateStrategy:
     type: RollingUpdate
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:


### PR DESCRIPTION
Is there any reason to keep using OrderedReady with either Kafka or Zookeeper? We still get ordered rolling updates after #55. The problem with OrderedReady is that for `kafka` and `pzoo` if the zone with the volume for index `0` is unavailable none of the other pods can be restarted.

@sibtainabbas10 I noticed you used `Parallel` in #28 back in January. Have you seen any issues?