### PR TITLE
Fix Zookeeper persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If you begin to rely on this kafka setup we recommend you fork, for example to e
 | ----- | ------ | ---------- |
 | v5.0.1 | 1.11+ | Fixes Zookeeper persistence [#227](https://github.com/Yolean/kubernetes-kafka/pull/227) |
 | v5.0  | 1.11+  | Destabilize because in Docker we want Java 11 [#197](https://github.com/Yolean/kubernetes-kafka/pull/197) [#191](https://github.com/Yolean/kubernetes-kafka/pull/191) |
+| v4.3.1 | 1.9+  | Critical Zookeeper persistence fix [#228](https://github.com/Yolean/kubernetes-kafka/pull/228) |
 | v4.3  | 1.9+   | Adds a prpper shutdown hook [207](https://github.com/Yolean/kubernetes-kafka/pull/207) |
 | v4.2  | 1.9+   | Kafka 1.0.2 and tools upgrade |
 | v4.1  | 1.9+   | Kafka 1.0.1 new [default](#148) [config](#170) |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you begin to rely on this kafka setup we recommend you fork, for example to e
 
 | tag   | k8s ≥  | highlights |
 | ----- | ------ | ---------- |
+| v5.0.1 | 1.11+ | Fixes Zookeeper persistence [#227](https://github.com/Yolean/kubernetes-kafka/pull/227) |
 | v5.0  | 1.11+  | Destabilize because in Docker we want Java 11 [#197](https://github.com/Yolean/kubernetes-kafka/pull/197) [#191](https://github.com/Yolean/kubernetes-kafka/pull/191) |
 | v4.3  | 1.9+   | Adds a prpper shutdown hook [207](https://github.com/Yolean/kubernetes-kafka/pull/207) |
 | v4.2  | 1.9+   | Kafka 1.0.2 and tools upgrade |

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -9,6 +9,7 @@ data:
     set -e
     set -x
 
+    [ -d /var/lib/zookeeper/data ] || mkdir /var/lib/zookeeper/data
     [ -z "$ID_OFFSET" ] && ID_OFFSET=1
     export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + $ID_OFFSET))
     echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -31,7 +31,7 @@ spec:
         - name: config
           mountPath: /etc/kafka
         - name: data
-          mountPath: /var/lib/zookeeper/data
+          mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
         image: solsson/kafka:2.1.0@sha256:ac3f06d87d45c7be727863f31e79fbfdcb9c610b51ba9cf03c75a95d602f15e1

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -57,7 +57,7 @@ spec:
             cpu: 10m
             memory: 100Mi
           limits:
-            memory: 100Mi
+            memory: 120Mi
         readinessProbe:
           exec:
             command:

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -68,7 +68,7 @@ spec:
         - name: config
           mountPath: /etc/kafka
         - name: data
-          mountPath: /var/lib/zookeeper/data
+          mountPath: /var/lib/zookeeper
       volumes:
       - name: configmap
         configMap:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -71,7 +71,7 @@ spec:
         - name: config
           mountPath: /etc/kafka
         - name: data
-          mountPath: /var/lib/zookeeper/data
+          mountPath: /var/lib/zookeeper
       volumes:
       - name: configmap
         configMap:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -34,7 +34,7 @@ spec:
         - name: config
           mountPath: /etc/kafka
         - name: data
-          mountPath: /var/lib/zookeeper/data
+          mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
         image: solsson/kafka:2.1.0@sha256:ac3f06d87d45c7be727863f31e79fbfdcb9c610b51ba9cf03c75a95d602f15e1

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -60,7 +60,7 @@ spec:
             cpu: 10m
             memory: 100Mi
           limits:
-            memory: 100Mi
+            memory: 120Mi
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
Topic information, though not the contents kept in Kafka, would be lost if all zookeeper pods had been down at the same time. Only the snapshots were actually saved to the persistent volume.

According to https://zookeeper.apache.org/doc/r3.4.13/zookeeperAdmin.html#sc_dataFileManagement "ZooKeeper can recover using this snapshot".

The regression probably dates back to https://github.com/Yolean/kubernetes-kafka/commit/ccb9e5df12e5dbe70f243432d1613bd101b35630 which was released with v2.0.0.