### PR TITLE
Upgrade path for the zookeeper persistence issue

### DIFF
--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -8,6 +8,7 @@ data:
     #!/bin/bash
     set -x
 
+    [ -d /var/lib/zookeeper/data ] || mkdir /var/lib/zookeeper/data
     [ -z "$ID_OFFSET" ] && ID_OFFSET=1
     export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + $ID_OFFSET))
     echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -30,7 +30,7 @@ spec:
         - name: config
           mountPath: /etc/kafka
         - name: data
-          mountPath: /var/lib/zookeeper/data
+          mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
         image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -65,7 +65,7 @@ spec:
         - name: config
           mountPath: /etc/kafka
         - name: data
-          mountPath: /var/lib/zookeeper/data
+          mountPath: /var/lib/zookeeper
       volumes:
       - name: configmap
         configMap:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -33,7 +33,7 @@ spec:
         - name: config
           mountPath: /etc/kafka
         - name: data
-          mountPath: /var/lib/zookeeper/data
+          mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
         image: solsson/kafka:1.0.2@sha256:7fdb326994bcde133c777d888d06863b7c1a0e80f043582816715d76643ab789

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -68,7 +68,7 @@ spec:
         - name: config
           mountPath: /etc/kafka
         - name: data
-          mountPath: /var/lib/zookeeper/data
+          mountPath: /var/lib/zookeeper
       volumes:
       - name: configmap
         configMap:


### PR DESCRIPTION
#227 for a v4.3.1 release, fixing #89, with an upgrade path to migrate your zookeeper state. Recovery from snapshots is an alternative, but I haven't looked into that.

v5.0.0 hasn't been out long enough for anyone to run anything important on, I suppose. Thus we should focus on how to migrate a 4.3.0 installation, that might have been running since v2.0.0. After this upgrade I think that it'll be a straightforward `kubectl replace` to go to v5.0.1.
