### PR TITLE
Allows a maximum of 1 connection to zookeeper per (pod) IP

### DIFF
--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -20,6 +20,7 @@ data:
     dataDir=/var/lib/zookeeper/data
     dataLogDir=/var/lib/zookeeper/log
     clientPort=2181
+    maxClientCnxns=1
     initLimit=5
     syncLimit=2
     server.1=pzoo-0.pzoo:2888:3888:participant


### PR DESCRIPTION
Part of the 5.0 destabilization effort :)

I like this kind of restrictions as sanity check. It discourages use of the Kafka pods for administration stuff (bad practice wrt resource limits etc) and use of legacy clients that connect directly to zookeeper. Zookeeper [docs](https://zookeeper.apache.org/doc/r3.4.13/zookeeperAdmin.html) also mentions "file descriptor exhaustion".

See the commit comment for the rationale behind the number 1. Sure, we'll increase it if anyone sees practical issues. For now it's on par with the [philosophy behind memory limits in 5.0.0](https://github.com/Yolean/kubernetes-kafka/blob/v5.0.0/kafka/50kafka.yml#L71).