### PR TITLE
Fix v5.0 regression that left zoo pods unreachable

### DIFF
--- a/zookeeper/21zoo-service.yml
+++ b/zookeeper/21zoo-service.yml
@@ -12,4 +12,4 @@ spec:
   clusterIP: None
   selector:
     app: zookeeper
-    storage: ephemeral
+    storage: persistent-regional


### PR DESCRIPTION
The destabilization effort with v5.0.0 is going great :)

I didn't notice this flaw until I experimented with scaling for https://github.com/Yolean/kubernetes-kafka/pull/228#issuecomment-443536263. The label change in #191 should have been reflected in the `zoo` service. It would have been apparent if I watched the logs during testing, with errors like:

```
[2018-12-02 20:00:24,587] WARN Failed to resolve address: zoo-1.zoo (org.apache.zookeeper.server.quorum.QuorumPeer)
java.net.UnknownHostException: zoo-1.zoo
	at java.base/java.net.InetAddress$CachedAddresses.get(InetAddress.java:797)
	at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1505)
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1364)
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1298)
	at java.base/java.net.InetAddress.getByName(InetAddress.java:1248)
	at org.apache.zookeeper.server.quorum.QuorumPeer$QuorumServer.recreateSocketAddresses(QuorumPeer.java:180)
	at org.apache.zookeeper.server.quorum.QuorumCnxManager.connectOne(QuorumCnxManager.java:591)
	at org.apache.zookeeper.server.quorum.QuorumCnxManager.toSend(QuorumCnxManager.java:534)
	at org.apache.zookeeper.server.quorum.FastLeaderElection$Messenger$WorkerSender.process(FastLeaderElection.java:454)
	at org.apache.zookeeper.server.quorum.FastLeaderElection$Messenger$WorkerSender.run(FastLeaderElection.java:435)
	at java.base/java.lang.Thread.run(Thread.java:834)
[2018-12-02 20:00:24,587] WARN Cannot open channel to 6 at election address zoo-2.zoo:3888 (org.apache.zookeeper.server.quorum.QuorumCnxManager)
java.net.UnknownHostException: zoo-2.zoo
	at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:220)
```

Maybe we should export prometheus metrics based on the `mntr` command, see https://zookeeper.apache.org/doc/r3.4.13/zookeeperAdmin.html#sc_zkCommands.