### PR TITLE
Fix the scale-2 variant and phase out pzoo

### DIFF
--- a/variants/scale-2/kafka-scale2-overrides.json
+++ b/variants/scale-2/kafka-scale2-overrides.json
@@ -1,0 +1,10 @@
+[
+  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "default.replication.factor=2"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "min.insync.replicas=2"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.replication.factor=2"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.num.partitions=2"}
+]

--- a/variants/scale-2/kustomization.yaml
+++ b/variants/scale-2/kustomization.yaml
@@ -5,3 +5,10 @@ bases:
 patchesStrategicMerge:
 - kafka.yaml
 - zookeeper.yaml
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: kafka
+  path: kafka-scale2-overrides.json

--- a/variants/scale-2/zookeeper.yaml
+++ b/variants/scale-2/zookeeper.yaml
@@ -1,26 +1,11 @@
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: pzoo
-  namespace: kafka
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pzoo
   namespace: kafka
 spec:
-  replicas: 2
-  template:
-    spec:
-      initContainers:
-      - name: init-config
-        env:
-        - name: PZOO_REPLICAS
-          value: '2'
-        - name: ZOO_REPLICAS
-          value: '1'
+  replicas: 0
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -36,8 +21,8 @@ spec:
         env:
         # There's no validation on these numbers adding up to a coherent zk config, so watch out
         - name: PZOO_REPLICAS
-          value: '2'
+          value: '0'
         - name: ZOO_REPLICAS
-          value: '1'
+          value: '2'
         - name: ID_OFFSET
-          value: '3'
+          value: '0'

--- a/variants/scale-2/zookeeper.yaml
+++ b/variants/scale-2/zookeeper.yaml
@@ -13,7 +13,7 @@ metadata:
   name: zoo
   namespace: kafka
 spec:
-  replicas: 1
+  replicas: 2
   template:
     spec:
       initContainers:
@@ -25,4 +25,4 @@ spec:
         - name: ZOO_REPLICAS
           value: '2'
         - name: ID_OFFSET
-          value: '0'
+          value: '1'

--- a/variants/scale-3-5-nopzoo/kustomization.yaml
+++ b/variants/scale-3-5-nopzoo/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../scale-3-5
+patchesStrategicMerge:
+- ./only-zoo-5.yaml

--- a/variants/scale-3-5-nopzoo/only-zoo-5.yaml
+++ b/variants/scale-3-5-nopzoo/only-zoo-5.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pzoo
+  namespace: kafka
+spec:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zoo
+  namespace: kafka
+spec:
+  replicas: 5
+  template:
+    spec:
+      initContainers:
+      - name: init-config
+        env:
+        # There's no validation on these numbers adding up to a coherent zk config, so watch out
+        - name: PZOO_REPLICAS
+          value: '0'
+        - name: ZOO_REPLICAS
+          value: '5'
+        - name: ID_OFFSET
+          value: '0'

--- a/variants/scale-3-5-nopzoo/only-zoo-5.yaml
+++ b/variants/scale-3-5-nopzoo/only-zoo-5.yaml
@@ -25,4 +25,4 @@ spec:
         - name: ZOO_REPLICAS
           value: '5'
         - name: ID_OFFSET
-          value: '0'
+          value: '1'


### PR DESCRIPTION
With storage class name abstracted out (#270) there's no reason other than backwards compatibility to keep pzoo. Except maybe if it helps in maintenance situations. Scaling zookeeper is a bit tricky due to all pods containing a static list of zk instances' DNS names.

I think this fixes #276, which is a duplicate of #123.