### PR TITLE
Support more than 10 brokers

### DIFF
--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -27,7 +27,7 @@ data:
       fi
 
       OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
-      OUTSIDE_PORT=3240${KAFKA_BROKER_ID}
+      OUTSIDE_PORT=$((32400 + ${KAFKA_BROKER_ID}))
       SEDS+=("s|#init#advertised.listeners=PLAINTEXT://#init#|advertised.listeners=PLAINTEXT://:9092,OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|")
       ANNOTATIONS="$ANNOTATIONS kafka-listener-outside-host=$OUTSIDE_HOST kafka-listener-outside-port=$OUTSIDE_PORT"
 


### PR DESCRIPTION
Use bash arithmetic operation rather than string concatenation to compute OUTSIDE_PORT.
This allows supporting arbitrary number of brokers.

This is my proposal for #285