### PR TITLE
Use default storage class

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -100,7 +100,7 @@ spec:
       name: data
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: standard
+      storageClassName: ""
       resources:
         requests:
           storage: 10Gi

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -100,7 +100,6 @@ spec:
       name: data
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: ""
       resources:
         requests:
           storage: 10Gi

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -80,7 +80,6 @@ spec:
       name: data
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: ""
       resources:
         requests:
           storage: 1Gi

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -80,7 +80,7 @@ spec:
       name: data
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: standard
+      storageClassName: ""
       resources:
         requests:
           storage: 1Gi

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -83,7 +83,6 @@ spec:
       name: data
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: ""
       resources:
         requests:
           storage: 1Gi

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -83,7 +83,7 @@ spec:
       name: data
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: standard
+      storageClassName: ""
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
Clusters without a default storage class can get one globally using:

```
kubectl patch storageclass NAME -p "{\"metadata\":{\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"}}}"
```

Note that existing statefulsets can't be upgraded with this change. Apply will result in `spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden`. When you already have volumes it's better to override storageclass like for example the GKE variant does: https://github.com/Yolean/kubernetes-kafka/blob/v6.0.3/variants/gke-regional/kustomization.yaml#L4 and https://github.com/Yolean/kubernetes-kafka/blob/v6.0.3/variants/gke-regional/gke-storageclass-broker-pd.yaml