### PR TITLE
Kafka 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Then pick and chose from patches our [example variants](https://github.com/Yolea
 
 | tag    | k8s ≥ | highlights  |
 | ------ | ----- | ----------- |
+|  TBD   | 1.13+ | Kafka [2.4.0](https://github.com/Yolean/kubernetes-kafka/pull/297) + [standard storage class](https://github.com/Yolean/kubernetes-kafka/pull/294) |
 | v6.0.0 | 1.11+ | Kafka 2.2.0 + `apply -k` (kubectl 1.14+) + [#270](https://github.com/Yolean/kubernetes-kafka/pull/270) |
 | v5.1.0 | 1.11+ | Kafka 2.1.1 |
 | v5.0.3 | 1.11+ | Zookeeper fix [#227](https://github.com/Yolean/kubernetes-kafka/pull/227) + [maxClientCnxns=1](https://github.com/Yolean/kubernetes-kafka/pull/230#issuecomment-445953857) |

--- a/avro-tools/test/rest-curl.yml
+++ b/avro-tools/test/rest-curl.yml
@@ -114,7 +114,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/avro-tools/test/rest-curl.yml
+++ b/avro-tools/test/rest-curl.yml
@@ -114,7 +114,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/avro-tools/test/rest-curl.yml
+++ b/avro-tools/test/rest-curl.yml
@@ -114,7 +114,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/cruise-control/50cruise-control.yml
+++ b/cruise-control/50cruise-control.yml
@@ -27,7 +27,7 @@ spec:
           mountPath: /opt/cruise-control/config
       containers:
       - name: cruise-control
-        image: solsson/kafka-cruise-control@sha256:981f57f26ec979d6d0794d3d34f22e6aad5ff189f9286b2c8c87fff66ccc0a15
+        image: solsson/kafka-cruise-control@sha256:f3f3775f3b5e2a5ae2da6fdae60ed118793ac32c80f13fba31be8f025a57f6ac
         imagePullPolicy: IfNotPresent
         ports:
         - name: api

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -45,7 +45,7 @@ spec:
           mountPath: /opt/kafka/libs/extensions
       containers:
       - name: broker
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         env:
         - name: CLASSPATH
           value: /opt/kafka/libs/extensions/*

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -45,7 +45,7 @@ spec:
           mountPath: /opt/kafka/libs/extensions
       containers:
       - name: broker
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
         - name: CLASSPATH
           value: /opt/kafka/libs/extensions/*

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -45,7 +45,7 @@ spec:
           mountPath: /opt/kafka/libs/extensions
       containers:
       - name: broker
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         env:
         - name: CLASSPATH
           value: /opt/kafka/libs/extensions/*

--- a/kafka/test/kafkacat.yml
+++ b/kafka/test/kafkacat.yml
@@ -81,10 +81,6 @@ spec:
         - --if-not-exists
         - --topic
         -   test-kafkacat
-        - --partitions
-        -   "3"
-        - --replication-factor
-        -   "2"
         resources:
           limits:
             cpu: 200m

--- a/kafka/test/produce-consume.yml
+++ b/kafka/test/produce-consume.yml
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
       - name: producer
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
         - name: BOOTSTRAP
           value: bootstrap.kafka:9092
@@ -127,7 +127,7 @@ spec:
         - name: shared
           mountPath: /shared
       - name: consumer
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
         - name: BOOTSTRAP
           value: bootstrap.kafka:9092

--- a/kafka/test/produce-consume.yml
+++ b/kafka/test/produce-consume.yml
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
       - name: producer
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         env:
         - name: BOOTSTRAP
           value: bootstrap.kafka:9092
@@ -127,7 +127,7 @@ spec:
         - name: shared
           mountPath: /shared
       - name: consumer
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         env:
         - name: BOOTSTRAP
           value: bootstrap.kafka:9092

--- a/kafka/test/produce-consume.yml
+++ b/kafka/test/produce-consume.yml
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
       - name: producer
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         env:
         - name: BOOTSTRAP
           value: bootstrap.kafka:9092
@@ -127,7 +127,7 @@ spec:
         - name: shared
           mountPath: /shared
       - name: consumer
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         env:
         - name: BOOTSTRAP
           value: bootstrap.kafka:9092

--- a/maintenance/preferred-replica-election-job.yml
+++ b/maintenance/preferred-replica-election-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         command:
         - ./bin/kafka-preferred-replica-election.sh
         - --zookeeper

--- a/maintenance/preferred-replica-election-job.yml
+++ b/maintenance/preferred-replica-election-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         command:
         - ./bin/kafka-preferred-replica-election.sh
         - --zookeeper

--- a/maintenance/preferred-replica-election-job.yml
+++ b/maintenance/preferred-replica-election-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         command:
         - ./bin/kafka-preferred-replica-election.sh
         - --zookeeper

--- a/maintenance/reassign-paritions-job.yml
+++ b/maintenance/reassign-paritions-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         env:
         - name: ZOOKEEPER
           value: zookeeper.kafka:2181

--- a/maintenance/reassign-paritions-job.yml
+++ b/maintenance/reassign-paritions-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
         - name: ZOOKEEPER
           value: zookeeper.kafka:2181

--- a/maintenance/reassign-paritions-job.yml
+++ b/maintenance/reassign-paritions-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         env:
         - name: ZOOKEEPER
           value: zookeeper.kafka:2181

--- a/maintenance/replication-factor-increase-job.yml
+++ b/maintenance/replication-factor-increase-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         env:
         - name: ZOOKEEPER
           value: zookeeper.kafka:2181

--- a/maintenance/replication-factor-increase-job.yml
+++ b/maintenance/replication-factor-increase-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
         - name: ZOOKEEPER
           value: zookeeper.kafka:2181

--- a/maintenance/replication-factor-increase-job.yml
+++ b/maintenance/replication-factor-increase-job.yml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         env:
         - name: ZOOKEEPER
           value: zookeeper.kafka:2181

--- a/maintenance/test/replicated-partitions.yml
+++ b/maintenance/test/replicated-partitions.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         command:
         - /bin/bash
         - -ec

--- a/maintenance/test/replicated-partitions.yml
+++ b/maintenance/test/replicated-partitions.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         command:
         - /bin/bash
         - -ec

--- a/maintenance/test/replicated-partitions.yml
+++ b/maintenance/test/replicated-partitions.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         command:
         - /bin/bash
         - -ec

--- a/yahoo-kafka-manager/kafka-manager.yml
+++ b/yahoo-kafka-manager/kafka-manager.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: kafka-manager
-        image: solsson/kafka-manager@sha256:da602758fd542139284d1d106e7dfed78898e0f1eb9756597ab9aee8cfccd763
+        image: solsson/kafka-manager@sha256:9da595ecbb733074a1d3c6091a1e0c384da4f4e1f19f4e16276062278da8e592
         ports:
         - containerPort: 80
         env:

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -22,6 +22,7 @@ data:
     sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" /etc/kafka/zookeeper.properties
 
   zookeeper.properties: |
+    4lw.commands.whitelist=ruok
     tickTime=2000
     dataDir=/var/lib/zookeeper/data
     dataLogDir=/var/lib/zookeeper/log

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -34,7 +34,7 @@ spec:
           mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -34,7 +34,7 @@ spec:
           mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -34,7 +34,7 @@ spec:
           mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -37,7 +37,7 @@ spec:
           mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
-        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
+        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -37,7 +37,7 @@ spec:
           mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
-        image: solsson/kafka:2.4.0@sha256:17f35e6dc3b5687107e0dae4cc0f3fc30d6613724e7b75fc1ed4d1a6f0744965
+        image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -37,7 +37,7 @@ spec:
           mountPath: /var/lib/zookeeper
       containers:
       - name: zookeeper
-        image: solsson/kafka:2.3.0@sha256:b59603a8c0645f792fb54e9571500e975206352a021d6a116b110945ca6c3a1d
+        image: solsson/kafka:latest@sha256:bc6aa2962c772733a07ed9ccbc48c8b218f8c42889c83e251665d193015a2a2f
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties


### PR DESCRIPTION
Highlights for us include:

- Consume from nearest replica, https://issues.apache.org/jira/browse/KAFKA-8443. Until now #41 was good for resilience, but now it might also help performance.
- We could have a leader election job, https://issues.apache.org/jira/browse/KAFKA-8286
- Dynamic log levels, could also be a job, https://issues.apache.org/jira/browse/KAFKA-7800
- We could possibly speed up some automated group consumer setups thanks to https://issues.apache.org/jira/browse/KAFKA-7471
- Topic creation jobs no longer _need_ to decide on replication factor and partitions, https://issues.apache.org/jira/browse/KAFKA-8305, which helps when we want to reuse automation across prod and development