### PR TITLE
Echo not working properly with "-e" in sh

### DIFF
--- a/cruise-control/20kafka-broker-reporter-patch.yml
+++ b/cruise-control/20kafka-broker-reporter-patch.yml
@@ -10,7 +10,7 @@ spec:
       - name: cruise-control-reporter
         image: solsson/kafka-cruise-control@sha256:c70eae329b4ececba58e8cf4fa6e774dd2e0205988d8e5be1a70e622fcc46716
         command:
-        - /bin/sh
+        - /bin/bash
         - -cex
         - |
           cp -v /opt/cruise-control/cruise-control/build/dependant-libs/cruise-control-metrics-reporter.jar /opt/kafka/libs/extensions/cruise-control-metrics-reporter.jar


### PR DESCRIPTION
In this container, running 

`echo -e "\n\nmetric.reporters = com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter" | tee -a /etc/kafka/server.properties`

Returns


```
group.initial.rebalance.delay.ms=8000-e

metric.reporters = com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
```

I believe sh is having some unexpected behavior when using the `-e` flag, but this command functions as intended when using bash. Bash is already included in this container.