### PR TITLE
Fix: add namespace to StatefulSet patch in scale-1

### DIFF
--- a/variants/scale-1/kustomization.yaml
+++ b/variants/scale-1/kustomization.yaml
@@ -11,4 +11,5 @@ patchesJson6902:
     version: v1
     kind: StatefulSet
     name: kafka
+    namespace: kafka
   path: kafka-scale1-overrides.json


### PR DESCRIPTION
Without this, the variant (as well as any variant that depends on it) cannot be used as base for `kustomize` (but it does work with `kubectl -k`).

```
$ kustomize build variants/scale-1/
Error: no matches for OriginalId apps_v1_StatefulSet|~X|kafka; no matches for CurrentId apps_v1_StatefulSet|~X|kafka; failed to find unique target for patch apps_v1_StatefulSet|kafka
```