### PR TITLE
Allow override of listener name

### DIFF
--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -28,7 +28,7 @@ data:
 
       OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
       OUTSIDE_PORT=$((32400 + ${KAFKA_BROKER_ID}))
-      SEDS+=("s|#init#advertised.listeners=PLAINTEXT://#init#|advertised.listeners=PLAINTEXT://:9092,OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|")
+      SEDS+=("s|#init#advertised.listeners=PLAINTEXT://#init#|advertised.listeners=PLAINTEXT://${ADVERTISE_ADDRESS}:9092,OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|")
       ANNOTATIONS="$ANNOTATIONS kafka-listener-outside-host=$OUTSIDE_HOST kafka-listener-outside-port=$OUTSIDE_PORT"
 
       if [ ! -z "$LABELS" ]; then

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -26,9 +26,10 @@ data:
         LABELS="$LABELS kafka-broker-rack=$ZONE"
       fi
 
+      [ -z "$INSIDE_HOST" ] && echo "INSIDE_HOST is empty, will advetise detected DNS name"
       OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
       OUTSIDE_PORT=$((32400 + ${KAFKA_BROKER_ID}))
-      SEDS+=("s|#init#advertised.listeners=PLAINTEXT://#init#|advertised.listeners=PLAINTEXT://${ADVERTISE_ADDRESS}:9092,OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|")
+      SEDS+=("s|#init#advertised.listeners=PLAINTEXT://#init#|advertised.listeners=PLAINTEXT://${INSIDE_HOST}:9092,OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|")
       ANNOTATIONS="$ANNOTATIONS kafka-listener-outside-host=$OUTSIDE_HOST kafka-listener-outside-port=$OUTSIDE_PORT"
 
       if [ ! -z "$LABELS" ]; then

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -26,10 +26,10 @@ data:
         LABELS="$LABELS kafka-broker-rack=$ZONE"
       fi
 
-      [ -z "$INSIDE_HOST" ] && echo "INSIDE_HOST is empty, will advetise detected DNS name"
+      [ -z "$ADVERTISE_ADDR" ] && echo "ADVERTISE_ADDR is empty, will advertise detected DNS name"
       OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
       OUTSIDE_PORT=$((32400 + ${KAFKA_BROKER_ID}))
-      SEDS+=("s|#init#advertised.listeners=PLAINTEXT://#init#|advertised.listeners=PLAINTEXT://${INSIDE_HOST}:9092,OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|")
+      SEDS+=("s|#init#advertised.listeners=PLAINTEXT://#init#|advertised.listeners=PLAINTEXT://${ADVERTISE_ADDR}:9092,OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|")
       ANNOTATIONS="$ANNOTATIONS kafka-listener-outside-host=$OUTSIDE_HOST kafka-listener-outside-port=$OUTSIDE_PORT"
 
       if [ ! -z "$LABELS" ]; then

--- a/variants/advertise-pod-ip/kafka.yaml
+++ b/variants/advertise-pod-ip/kafka.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: init-config
+        env:
+        - name: ADVERTISE_ADDR
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP

--- a/variants/advertise-pod-ip/kustomization.yaml
+++ b/variants/advertise-pod-ip/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../scale-3-5
+patchesStrategicMerge:
+- kafka.yaml


### PR DESCRIPTION
... and demonstrate how to advertise pod-IPs instead of the default `kafka-X.broker.kafka.svc.cluster.local:9092`.