### PR TITLE
Suffix properties file name with pod name

### DIFF
--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -41,6 +41,7 @@ data:
     }
     printf '%s\n' "${SEDS[@]}" | sed -f - /etc/kafka-configmap/server.properties > /etc/kafka/server.properties.tmp
     [ $? -eq 0 ] && mv /etc/kafka/server.properties.tmp /etc/kafka/server.properties
+    ln -s /etc/kafka/server.properties /etc/kafka/server.properties.$POD_NAME
 
   server.properties: |-
     ############################# Log Basics #############################

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -47,6 +47,10 @@ spec:
       - name: broker
         image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: CLASSPATH
           value: /opt/kafka/libs/extensions/*
         - name: KAFKA_LOG4J_OPTS
@@ -62,7 +66,7 @@ spec:
           containerPort: 5555
         command:
         - ./bin/kafka-server-start.sh
-        - /etc/kafka/server.properties
+        - /etc/kafka/server.properties.$(POD_NAME)
         lifecycle:
           preStop:
             exec:

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -20,6 +20,7 @@ data:
       for N in $(seq $ZOO_REPLICAS); do echo "server.$(( $PZOO_REPLICAS + $N ))=zoo-$(( $N - 1 )).zoo:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
     }
     sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" /etc/kafka/zookeeper.properties
+    ln -s /etc/kafka/zookeeper.properties /etc/kafka/zookeeper.properties.$POD_NAME
 
   zookeeper.properties: |
     4lw.commands.whitelist=ruok

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -14,13 +14,14 @@ data:
     export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + $ID_OFFSET))
     echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid
     cp -Lur /etc/kafka-configmap/* /etc/kafka/
+    REPLICAS=$(( PZOO_REPLICAS + ZOO_REPLICAS ))
     [ ! -z "$PZOO_REPLICAS" ] && [ ! -z "$ZOO_REPLICAS" ] && {
       sed -i "s/^server\\./#server./" /etc/kafka/zookeeper.properties
       for N in $(seq $PZOO_REPLICAS); do echo "server.$N=pzoo-$(( $N - 1 )).pzoo:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
       for N in $(seq $ZOO_REPLICAS); do echo "server.$(( $PZOO_REPLICAS + $N ))=zoo-$(( $N - 1 )).zoo:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
     }
     sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" /etc/kafka/zookeeper.properties
-    ln -s /etc/kafka/zookeeper.properties /etc/kafka/zookeeper.properties.$POD_NAME
+    ln -s /etc/kafka/zookeeper.properties /etc/kafka/zookeeper.properties.scale-$REPLICAS.$POD_NAME
 
   zookeeper.properties: |
     4lw.commands.whitelist=ruok

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -25,6 +25,11 @@ spec:
       - name: init-config
         image: solsson/kafka-initutils@sha256:f6d9850c6c3ad5ecc35e717308fddb47daffbde18eb93e98e031128fe8b899ef
         command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         volumeMounts:
         - name: configmap
           mountPath: /etc/kafka-configmap
@@ -36,11 +41,15 @@ spec:
       - name: zookeeper
         image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         command:
         - ./bin/zookeeper-server-start.sh
-        - /etc/kafka/zookeeper.properties
+        - /etc/kafka/zookeeper.properties.$(POD_NAME)
         lifecycle:
           preStop:
             exec:

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -49,7 +49,7 @@ spec:
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         command:
         - ./bin/zookeeper-server-start.sh
-        - /etc/kafka/zookeeper.properties.$(POD_NAME)
+        - /etc/kafka/zookeeper.properties.scale-5.$(POD_NAME)
         lifecycle:
           preStop:
             exec:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -51,7 +51,7 @@ spec:
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         command:
         - ./bin/zookeeper-server-start.sh
-        - /etc/kafka/zookeeper.properties.$(POD_NAME)
+        - /etc/kafka/zookeeper.properties.scale-5.$(POD_NAME)
         lifecycle:
           preStop:
             exec:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -26,6 +26,10 @@ spec:
         image: solsson/kafka-initutils@sha256:f6d9850c6c3ad5ecc35e717308fddb47daffbde18eb93e98e031128fe8b899ef
         command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: ID_OFFSET
           value: "4"
         volumeMounts:
@@ -39,11 +43,15 @@ spec:
       - name: zookeeper
         image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         command:
         - ./bin/zookeeper-server-start.sh
-        - /etc/kafka/zookeeper.properties
+        - /etc/kafka/zookeeper.properties.$(POD_NAME)
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
Because I'd like to explore ways to transition to static configuration, rather than generating config at init. A completely static config would for be more transparent and could, with for example Kustomize's configmap hashes, support rolling updates better.

While investigating if broker ID could be an `--override` instead I found two blockers:

 - Oddly the label that was introduced for statefulsets (after this repo's inception) sets the pod name, not the ordinal.
 - Zookeeper needs to be 1-indexed.

I had this comment in code when I was amazed over the design with pod-name instead of pod-ordinal (the former is trivial to create with env expansion):

```
+++ b/kafka/50kafka.yml
@@ -30,6 +30,9 @@ spec:
         - name: POD_NAME
           valueFrom:
             fieldRef:
+              # Is there any benefit to using this field over metadata.name? fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
+              # https://github.com/kubernetes/community/pull/147#issuecomment-350783043
+              # https://github.com/kubernetes/kubernetes/pull/68719 -> new env with fieldPath: metadata.labels['statefulset.kubernetes.io/pod-ordinal']
               fieldPath: metadata.name
```
It looks like pod-ordinal didn't make it into 1.18.
