### PR TITLE
Troubleshoot zookeeper connection failures

### DIFF
--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -63,7 +63,7 @@ spec:
           name: leader-election
         resources:
           requests:
-            cpu: 10m
+            cpu: 30m
             memory: 100Mi
           limits:
             memory: 120Mi

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -65,7 +65,7 @@ spec:
           name: leader-election
         resources:
           requests:
-            cpu: 10m
+            cpu: 30m
             memory: 100Mi
           limits:
             memory: 120Mi


### PR DESCRIPTION
I've experimented with a 3-kafka 5-zk cluster on a 3-node GKE e2-small cluster, i.e. just enough resources to run the Kafka stack together with some basic infra. During tests I occasionally get kafka pods restarting due to failures to connect to zookeeper. Also clients like the kafka-topics CLI had troubles connecting. No zookeeper restarts, no OOMKilled. See the first commit comment for some stack traces.