### PR TITLE
Extract entrypoint command from bin scripts, try native-image zookeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Then pick and chose from patches our [example variants](https://github.com/Yolea
 ## Version history
 
 | tag    | k8s ≥ | highlights  |
+| ------ | ----- | ----------- |
 | v7.0.0 | 1.15+ | [Breaking](https://github.com/Yolean/kubernetes-kafka/pull/311#issuecomment-657181714) with [nonroot](./nonroot/) and [native](./native/) bases |
 | v6.0.x | 1.13+ | Kafka [2.4.0](https://github.com/Yolean/kubernetes-kafka/pull/297) + [standard storage class](https://github.com/Yolean/kubernetes-kafka/pull/294) |
 | v6.0.0 | 1.11+ | Kafka 2.2.0 + `apply -k` (kubectl 1.14+) + [#270](https://github.com/Yolean/kubernetes-kafka/pull/270) |

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Then pick and chose from patches our [example variants](https://github.com/Yolea
 ## Version history
 
 | tag    | k8s ≥ | highlights  |
-| ------ | ----- | ----------- |
-|  TBD   | 1.13+ | Kafka [2.4.0](https://github.com/Yolean/kubernetes-kafka/pull/297) + [standard storage class](https://github.com/Yolean/kubernetes-kafka/pull/294) |
+| v7.0.0 | 1.15+ | [Breaking](https://github.com/Yolean/kubernetes-kafka/pull/311#issuecomment-657181714) with [nonroot](./nonroot/) and [native](./native/) bases |
+| v6.0.x | 1.13+ | Kafka [2.4.0](https://github.com/Yolean/kubernetes-kafka/pull/297) + [standard storage class](https://github.com/Yolean/kubernetes-kafka/pull/294) |
 | v6.0.0 | 1.11+ | Kafka 2.2.0 + `apply -k` (kubectl 1.14+) + [#270](https://github.com/Yolean/kubernetes-kafka/pull/270) |
 | v5.1.0 | 1.11+ | Kafka 2.1.1 |
 | v5.0.3 | 1.11+ | Zookeeper fix [#227](https://github.com/Yolean/kubernetes-kafka/pull/227) + [maxClientCnxns=1](https://github.com/Yolean/kubernetes-kafka/pull/230#issuecomment-445953857) |

--- a/consumers-prometheus/kafka-minion.yaml
+++ b/consumers-prometheus/kafka-minion.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: kafka-minion
-        image: solsson/kafka-consumers-prometheus@sha256:039d0bc0c1bdfa8b2e515e4c05ab8490492c65b43830579ce76d36278f33d447
+        image: solsson/kafka-consumers-prometheus@sha256:b5f5b8672397f94379a5a3e8b4bf41cf12b64ff1c4fc7f84684edca4beb37c16
         env:
         - name: TELEMETRY_HOST
           value: 0.0.0.0

--- a/cruise-control/50cruise-control.yml
+++ b/cruise-control/50cruise-control.yml
@@ -27,7 +27,7 @@ spec:
           mountPath: /opt/cruise-control/config
       containers:
       - name: cruise-control
-        image: solsson/kafka-cruise-control@sha256:f3f3775f3b5e2a5ae2da6fdae60ed118793ac32c80f13fba31be8f025a57f6ac
+        image: solsson/kafka-cruise-control@sha256:2c2d113ec3d960bfa75e8e51d1fed6a2f2818e329990f61c895e611403ba64d0
         imagePullPolicy: IfNotPresent
         ports:
         - name: api

--- a/cruise-control/topic-create.yml
+++ b/cruise-control/topic-create.yml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:native-cli@sha256:7a4cc4ef875aea50b8d4dbb525cbac0ef3a5c6e611fcafc2c415ca432ebe5601
+        image: solsson/kafka:native-cli@sha256:fbf29c59182fb87921c5199783d2d5796856ecbfe34a9c03eca658b3cf50f3c4
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/events-kube/topic-create.yaml
+++ b/events-kube/topic-create.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:native-cli@sha256:7a4cc4ef875aea50b8d4dbb525cbac0ef3a5c6e611fcafc2c415ca432ebe5601
+        image: solsson/kafka:native-cli@sha256:fbf29c59182fb87921c5199783d2d5796856ecbfe34a9c03eca658b3cf50f3c4
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -41,6 +41,7 @@ data:
     }
     printf '%s\n' "${SEDS[@]}" | sed -f - /etc/kafka-configmap/server.properties > /etc/kafka/server.properties.tmp
     [ $? -eq 0 ] && mv /etc/kafka/server.properties.tmp /etc/kafka/server.properties
+    ln -s /etc/kafka/server.properties /etc/kafka/server.properties.$POD_NAME
 
   server.properties: |-
     ############################# Log Basics #############################

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -51,6 +51,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: CLASSPATH
           value: /opt/kafka/libs/extensions/*
         - name: KAFKA_LOG4J_OPTS

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -47,6 +47,10 @@ spec:
       - name: broker
         image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: CLASSPATH
           value: /opt/kafka/libs/extensions/*
         - name: KAFKA_LOG4J_OPTS
@@ -62,7 +66,7 @@ spec:
           containerPort: 5555
         command:
         - ./bin/kafka-server-start.sh
-        - /etc/kafka/server.properties
+        - /etc/kafka/server.properties.$(POD_NAME)
         lifecycle:
           preStop:
             exec:

--- a/kafka/test/kafkacat.yml
+++ b/kafka/test/kafkacat.yml
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:native-cli@sha256:7a4cc4ef875aea50b8d4dbb525cbac0ef3a5c6e611fcafc2c415ca432ebe5601
+        image: solsson/kafka:native-cli@sha256:fbf29c59182fb87921c5199783d2d5796856ecbfe34a9c03eca658b3cf50f3c4
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/kafka/test/produce-consume.yml
+++ b/kafka/test/produce-consume.yml
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:native-cli@sha256:7a4cc4ef875aea50b8d4dbb525cbac0ef3a5c6e611fcafc2c415ca432ebe5601
+        image: solsson/kafka:native-cli@sha256:fbf29c59182fb87921c5199783d2d5796856ecbfe34a9c03eca658b3cf50f3c4
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper

--- a/native/distroless.yaml
+++ b/native/distroless.yaml
@@ -1,0 +1,9 @@
+# The more specific removes are to make sure that there was a shell that we're removing
+- op: remove
+  path: /spec/template/spec/containers/0/readinessProbe/exec
+- op: remove
+  path: /spec/template/spec/containers/0/readinessProbe
+- op: remove
+  path: /spec/template/spec/containers/0/lifecycle/preStop/exec
+- op: remove
+  path: /spec/template/spec/containers/0/lifecycle/preStop

--- a/native/kustomization.yaml
+++ b/native/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../nonroot
+patchesStrategicMerge:
+- native-image-zookeeper.yaml

--- a/native/kustomization.yaml
+++ b/native/kustomization.yaml
@@ -2,3 +2,16 @@ bases:
 - ../nonroot
 patchesStrategicMerge:
 - native-image-zookeeper.yaml
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pzoo
+  path: distroless.yaml
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: zoo
+  path: distroless.yaml

--- a/native/native-image-zookeeper.yaml
+++ b/native/native-image-zookeeper.yaml
@@ -10,10 +10,7 @@ spec:
         image: solsson/kafka:native-zookeeper-server-start@sha256:0047f1ab4c7b79062c44e9bd2ad02aaf1124d8a0ed3309229e627cdd11a37c2a
         resources:
           requests:
-            cpu: 50m
-            memory: 25Mi
-          limits:
-            cpu: 50m
+            cpu: 10m
             memory: 25Mi
 ---
 apiVersion: apps/v1
@@ -28,8 +25,5 @@ spec:
         image: solsson/kafka:native-zookeeper-server-start@sha256:0047f1ab4c7b79062c44e9bd2ad02aaf1124d8a0ed3309229e627cdd11a37c2a
         resources:
           requests:
-            cpu: 50m
-            memory: 25Mi
-          limits:
-            cpu: 50m
+            cpu: 10m
             memory: 25Mi

--- a/native/native-image-zookeeper.yaml
+++ b/native/native-image-zookeeper.yaml
@@ -8,6 +8,13 @@ spec:
       containers:
       - name: zookeeper
         image: solsson/kafka:native-zookeeper-server-start@sha256:fb7b0ea81e3490f088de1491afcdde8f7531477f125781c726dfbbffb2695a01
+        resources:
+          requests:
+            cpu: 15m
+            memory: 25Mi
+          limits:
+            cpu: 15m
+            memory: 25Mi
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -19,3 +26,10 @@ spec:
       containers:
       - name: zookeeper
         image: solsson/kafka:native-zookeeper-server-start@sha256:fb7b0ea81e3490f088de1491afcdde8f7531477f125781c726dfbbffb2695a01
+        resources:
+          requests:
+            cpu: 15m
+            memory: 25Mi
+          limits:
+            cpu: 15m
+            memory: 25Mi

--- a/native/native-image-zookeeper.yaml
+++ b/native/native-image-zookeeper.yaml
@@ -10,10 +10,10 @@ spec:
         image: solsson/kafka:native-zookeeper-server-start@sha256:fb7b0ea81e3490f088de1491afcdde8f7531477f125781c726dfbbffb2695a01
         resources:
           requests:
-            cpu: 15m
+            cpu: 50m
             memory: 25Mi
           limits:
-            cpu: 15m
+            cpu: 50m
             memory: 25Mi
 ---
 apiVersion: apps/v1
@@ -28,8 +28,8 @@ spec:
         image: solsson/kafka:native-zookeeper-server-start@sha256:fb7b0ea81e3490f088de1491afcdde8f7531477f125781c726dfbbffb2695a01
         resources:
           requests:
-            cpu: 15m
+            cpu: 50m
             memory: 25Mi
           limits:
-            cpu: 15m
+            cpu: 50m
             memory: 25Mi

--- a/native/native-image-zookeeper.yaml
+++ b/native/native-image-zookeeper.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:native-zookeeper-server-start@sha256:0047f1ab4c7b79062c44e9bd2ad02aaf1124d8a0ed3309229e627cdd11a37c2a
+        image: solsson/kafka:native-zookeeper-server-start@sha256:ba3a0632240b8906a3b5bb6441e98ad9d9de73cb716b156ca68f1b435c819e8b
         resources:
           requests:
             cpu: 10m
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:native-zookeeper-server-start@sha256:0047f1ab4c7b79062c44e9bd2ad02aaf1124d8a0ed3309229e627cdd11a37c2a
+        image: solsson/kafka:native-zookeeper-server-start@sha256:ba3a0632240b8906a3b5bb6441e98ad9d9de73cb716b156ca68f1b435c819e8b
         resources:
           requests:
             cpu: 10m

--- a/native/native-image-zookeeper.yaml
+++ b/native/native-image-zookeeper.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pzoo
+spec:
+  template:
+    spec:
+      containers:
+      - name: zookeeper
+        image: solsson/kafka:native-zookeeper-server-start@sha256:fb7b0ea81e3490f088de1491afcdde8f7531477f125781c726dfbbffb2695a01
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zoo
+spec:
+  template:
+    spec:
+      containers:
+      - name: zookeeper
+        image: solsson/kafka:native-zookeeper-server-start@sha256:fb7b0ea81e3490f088de1491afcdde8f7531477f125781c726dfbbffb2695a01

--- a/native/native-image-zookeeper.yaml
+++ b/native/native-image-zookeeper.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:native-zookeeper-server-start@sha256:fb7b0ea81e3490f088de1491afcdde8f7531477f125781c726dfbbffb2695a01
+        image: solsson/kafka:native-zookeeper-server-start@sha256:0047f1ab4c7b79062c44e9bd2ad02aaf1124d8a0ed3309229e627cdd11a37c2a
         resources:
           requests:
             cpu: 50m
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:native-zookeeper-server-start@sha256:fb7b0ea81e3490f088de1491afcdde8f7531477f125781c726dfbbffb2695a01
+        image: solsson/kafka:native-zookeeper-server-start@sha256:0047f1ab4c7b79062c44e9bd2ad02aaf1124d8a0ed3309229e627cdd11a37c2a
         resources:
           requests:
             cpu: 50m

--- a/nonroot/entrypoint-from-image.yaml
+++ b/nonroot/entrypoint-from-image.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/template/spec/containers/0/command

--- a/nonroot/kustomization.yaml
+++ b/nonroot/kustomization.yaml
@@ -21,7 +21,24 @@ patchesJson6902:
     kind: StatefulSet
     name: zoo
   path: fsgroup-65534.yaml
-# https://github.com/kubernetes-sigs/kustomize/issues/915#issuecomment-477808963
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: kafka
+  path: entrypoint-from-image.yaml
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pzoo
+  path: entrypoint-from-image.yaml
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: zoo
+  path: entrypoint-from-image.yaml
 patchesStrategicMerge:
 - nonroot-image-kafka.yaml
 - nonroot-image-zookeeper.yaml

--- a/nonroot/kustomization.yaml
+++ b/nonroot/kustomization.yaml
@@ -2,6 +2,9 @@ bases:
 - ../rbac-namespace-default
 - ../kafka
 - ../zookeeper
+patchesStrategicMerge:
+- nonroot-image-kafka.yaml
+- nonroot-image-zookeeper.yaml
 patchesJson6902:
 - target:
     group: apps
@@ -39,6 +42,3 @@ patchesJson6902:
     kind: StatefulSet
     name: zoo
   path: entrypoint-from-image.yaml
-patchesStrategicMerge:
-- nonroot-image-kafka.yaml
-- nonroot-image-zookeeper.yaml

--- a/nonroot/nonroot-image-kafka.yaml
+++ b/nonroot/nonroot-image-kafka.yaml
@@ -7,6 +7,6 @@ spec:
     spec:
       containers:
       - name: broker
-        image: solsson/kafka:kafka-server-start-2.4.0@sha256:48a80cb0a5600ef5621a4c2c42ceab2c210e52619100a7bfe62f8bd871c38f2a
+        image: solsson/kafka:kafka-server-start-2.4.1@sha256:d7fb916c23fb6a7ad3f9cb9036eb8092a7667e31ce47cee216536566ca35c607
         args:
         - /etc/kafka/server.properties.$(POD_NAME)

--- a/nonroot/nonroot-image-kafka.yaml
+++ b/nonroot/nonroot-image-kafka.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: init-config
+        image: solsson/kafka:initutils-nonroot@sha256:87f6bb39fd47a6f382018a2dc55a484d1b71eee48a58019c7e65a9bc53e8dca2
       containers:
       - name: broker
         image: solsson/kafka:2.5.0-kafka-server-start@sha256:c6d43d1240c358d9ab8bb60de61a0b9578f04fd727ee4016f7706800998e5351

--- a/nonroot/nonroot-image-kafka.yaml
+++ b/nonroot/nonroot-image-kafka.yaml
@@ -7,6 +7,6 @@ spec:
     spec:
       containers:
       - name: broker
-        image: solsson/kafka:2.4.1-kafka-server-start@sha256:efeb80cbe35d7a39fd5d20fe93f201d3562f9914ac67afe594fe9720d21e58fa
+        image: solsson/kafka:2.5.0-kafka-server-start@sha256:c6d43d1240c358d9ab8bb60de61a0b9578f04fd727ee4016f7706800998e5351
         args:
         - /etc/kafka/server.properties.$(POD_NAME)

--- a/nonroot/nonroot-image-kafka.yaml
+++ b/nonroot/nonroot-image-kafka.yaml
@@ -7,6 +7,6 @@ spec:
     spec:
       containers:
       - name: broker
-        image: solsson/kafka:kafka-server-start-2.4.1@sha256:d7fb916c23fb6a7ad3f9cb9036eb8092a7667e31ce47cee216536566ca35c607
+        image: solsson/kafka:2.4.1-kafka-server-start@sha256:efeb80cbe35d7a39fd5d20fe93f201d3562f9914ac67afe594fe9720d21e58fa
         args:
         - /etc/kafka/server.properties.$(POD_NAME)

--- a/nonroot/nonroot-image-kafka.yaml
+++ b/nonroot/nonroot-image-kafka.yaml
@@ -7,4 +7,6 @@ spec:
     spec:
       containers:
       - name: broker
-        image: solsson/kafka:nonroot-2.4.0@sha256:b7dbda9f1941711239fbc3095ea49ba74715a9b2e2e8ce9185106c2e878c06aa
+        image: solsson/kafka:kafka-server-start-2.4.0@sha256:48a80cb0a5600ef5621a4c2c42ceab2c210e52619100a7bfe62f8bd871c38f2a
+        args:
+        - /etc/kafka/server.properties.$(POD_NAME)

--- a/nonroot/nonroot-image-zookeeper.yaml
+++ b/nonroot/nonroot-image-zookeeper.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:zookeeper-server-start-2.4.0@sha256:6037e1b5c103a638ef3e8fdd4c052527afb5cebbf13b005f5309a71fb2354c4e
+        image: solsson/kafka:zookeeper-server-start-2.4.1@sha256:ad92d8e93b369a4c6a9df7b8a198081dfcdcda52e218b1e707b39d63e1897cfb
         args:
         - /etc/kafka/zookeeper.properties.$(POD_NAME)
 ---
@@ -20,6 +20,6 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:zookeeper-server-start-2.4.0@sha256:6037e1b5c103a638ef3e8fdd4c052527afb5cebbf13b005f5309a71fb2354c4e
+        image: solsson/kafka:zookeeper-server-start-2.4.1@sha256:ad92d8e93b369a4c6a9df7b8a198081dfcdcda52e218b1e707b39d63e1897cfb
         args:
         - /etc/kafka/zookeeper.properties.$(POD_NAME)

--- a/nonroot/nonroot-image-zookeeper.yaml
+++ b/nonroot/nonroot-image-zookeeper.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: init-config
+        image: solsson/kafka:initutils-nonroot@sha256:87f6bb39fd47a6f382018a2dc55a484d1b71eee48a58019c7e65a9bc53e8dca2
       containers:
       - name: zookeeper
         image: solsson/kafka:2.5.0-zookeeper-server-start@sha256:4f9c68ff762c1419270dd72d38450f58cf130aa0c66f8359441075b4fe04de85
@@ -18,6 +21,9 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: init-config
+        image: solsson/kafka:initutils-nonroot@sha256:87f6bb39fd47a6f382018a2dc55a484d1b71eee48a58019c7e65a9bc53e8dca2
       containers:
       - name: zookeeper
         image: solsson/kafka:2.5.0-zookeeper-server-start@sha256:4f9c68ff762c1419270dd72d38450f58cf130aa0c66f8359441075b4fe04de85

--- a/nonroot/nonroot-image-zookeeper.yaml
+++ b/nonroot/nonroot-image-zookeeper.yaml
@@ -7,7 +7,9 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:nonroot-2.4.0@sha256:b7dbda9f1941711239fbc3095ea49ba74715a9b2e2e8ce9185106c2e878c06aa
+        image: solsson/kafka:zookeeper-server-start-2.4.0@sha256:6037e1b5c103a638ef3e8fdd4c052527afb5cebbf13b005f5309a71fb2354c4e
+        args:
+        - /etc/kafka/zookeeper.properties.$(POD_NAME)
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -18,4 +20,6 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:nonroot-2.4.0@sha256:b7dbda9f1941711239fbc3095ea49ba74715a9b2e2e8ce9185106c2e878c06aa
+        image: solsson/kafka:zookeeper-server-start-2.4.0@sha256:6037e1b5c103a638ef3e8fdd4c052527afb5cebbf13b005f5309a71fb2354c4e
+        args:
+        - /etc/kafka/zookeeper.properties.$(POD_NAME)

--- a/nonroot/nonroot-image-zookeeper.yaml
+++ b/nonroot/nonroot-image-zookeeper.yaml
@@ -9,7 +9,7 @@ spec:
       - name: zookeeper
         image: solsson/kafka:zookeeper-server-start-2.4.1@sha256:ad92d8e93b369a4c6a9df7b8a198081dfcdcda52e218b1e707b39d63e1897cfb
         args:
-        - /etc/kafka/zookeeper.properties.$(POD_NAME)
+        - /etc/kafka/zookeeper.properties.scale-5.$(POD_NAME)
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -22,4 +22,4 @@ spec:
       - name: zookeeper
         image: solsson/kafka:zookeeper-server-start-2.4.1@sha256:ad92d8e93b369a4c6a9df7b8a198081dfcdcda52e218b1e707b39d63e1897cfb
         args:
-        - /etc/kafka/zookeeper.properties.$(POD_NAME)
+        - /etc/kafka/zookeeper.properties.scale-5.$(POD_NAME)

--- a/nonroot/nonroot-image-zookeeper.yaml
+++ b/nonroot/nonroot-image-zookeeper.yaml
@@ -9,7 +9,7 @@ spec:
       - name: zookeeper
         image: solsson/kafka:zookeeper-server-start-2.4.1@sha256:ad92d8e93b369a4c6a9df7b8a198081dfcdcda52e218b1e707b39d63e1897cfb
         args:
-        - /etc/kafka/zookeeper.properties.scale-5.$(POD_NAME)
+        - /etc/kafka/zookeeper.properties.scale-$(REPLICAS).$(POD_NAME)
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -22,4 +22,4 @@ spec:
       - name: zookeeper
         image: solsson/kafka:zookeeper-server-start-2.4.1@sha256:ad92d8e93b369a4c6a9df7b8a198081dfcdcda52e218b1e707b39d63e1897cfb
         args:
-        - /etc/kafka/zookeeper.properties.scale-5.$(POD_NAME)
+        - /etc/kafka/zookeeper.properties.scale-$(REPLICAS).$(POD_NAME)

--- a/nonroot/nonroot-image-zookeeper.yaml
+++ b/nonroot/nonroot-image-zookeeper.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:2.4.1-zookeeper-server-start@sha256:b348f5cc2660a0ad885f24eaa28c1d6186cca86f1e30d33983e46712a3fab2f9
+        image: solsson/kafka:2.5.0-zookeeper-server-start@sha256:4f9c68ff762c1419270dd72d38450f58cf130aa0c66f8359441075b4fe04de85
         args:
         - /etc/kafka/zookeeper.properties.scale-$(REPLICAS).$(POD_NAME)
 ---
@@ -20,6 +20,6 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:2.4.1-zookeeper-server-start@sha256:b348f5cc2660a0ad885f24eaa28c1d6186cca86f1e30d33983e46712a3fab2f9
+        image: solsson/kafka:2.5.0-zookeeper-server-start@sha256:4f9c68ff762c1419270dd72d38450f58cf130aa0c66f8359441075b4fe04de85
         args:
         - /etc/kafka/zookeeper.properties.scale-$(REPLICAS).$(POD_NAME)

--- a/nonroot/nonroot-image-zookeeper.yaml
+++ b/nonroot/nonroot-image-zookeeper.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:zookeeper-server-start-2.4.1@sha256:ad92d8e93b369a4c6a9df7b8a198081dfcdcda52e218b1e707b39d63e1897cfb
+        image: solsson/kafka:2.4.1-zookeeper-server-start@sha256:b348f5cc2660a0ad885f24eaa28c1d6186cca86f1e30d33983e46712a3fab2f9
         args:
         - /etc/kafka/zookeeper.properties.scale-$(REPLICAS).$(POD_NAME)
 ---
@@ -20,6 +20,6 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: solsson/kafka:zookeeper-server-start-2.4.1@sha256:ad92d8e93b369a4c6a9df7b8a198081dfcdcda52e218b1e707b39d63e1897cfb
+        image: solsson/kafka:2.4.1-zookeeper-server-start@sha256:b348f5cc2660a0ad885f24eaa28c1d6186cca86f1e30d33983e46712a3fab2f9
         args:
         - /etc/kafka/zookeeper.properties.scale-$(REPLICAS).$(POD_NAME)

--- a/variants/dev-small/listener-localhost.json
+++ b/variants/dev-small/listener-localhost.json
@@ -1,4 +1,4 @@
 [
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/2", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/3", "value": "advertised.listeners=PLAINTEXT://:9092,OUTSIDE://localhost:9094"}
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/2", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/3", "value": "advertised.listeners=PLAINTEXT://:9092,OUTSIDE://localhost:9094"}
 ]

--- a/variants/dev-small/listener-localhost.json
+++ b/variants/dev-small/listener-localhost.json
@@ -1,4 +1,4 @@
 [
-  {"op": "add", "path": "/spec/template/spec/containers/0/args/2", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/args/3", "value": "advertised.listeners=PLAINTEXT://:9092,OUTSIDE://localhost:9094"}
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/1", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/2", "value": "advertised.listeners=PLAINTEXT://:9092,OUTSIDE://localhost:9094"}
 ]

--- a/variants/dev-small/num-partitions-1.json
+++ b/variants/dev-small/num-partitions-1.json
@@ -1,4 +1,4 @@
 [
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "num.partitions=1"}
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "num.partitions=1"}
 ]

--- a/variants/scale-1-ephemeral/kafka-scale1-overrides.json
+++ b/variants/scale-1-ephemeral/kafka-scale1-overrides.json
@@ -1,10 +1,10 @@
 [
-  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "default.replication.factor=1"},
-  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "min.insync.replicas=1"},
-  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "offsets.topic.replication.factor=1"},
-  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "offsets.topic.num.partitions=1"}
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "default.replication.factor=1"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "min.insync.replicas=1"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "offsets.topic.replication.factor=1"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "offsets.topic.num.partitions=1"}
 ]

--- a/variants/scale-1-ephemeral/kafka-scale1-overrides.json
+++ b/variants/scale-1-ephemeral/kafka-scale1-overrides.json
@@ -1,10 +1,10 @@
 [
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "default.replication.factor=1"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "min.insync.replicas=1"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.replication.factor=1"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.num.partitions=1"}
+  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "default.replication.factor=1"},
+  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "min.insync.replicas=1"},
+  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "offsets.topic.replication.factor=1"},
+  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/args/0/command/-", "value": "offsets.topic.num.partitions=1"}
 ]

--- a/variants/scale-1/kafka-scale1-overrides.json
+++ b/variants/scale-1/kafka-scale1-overrides.json
@@ -1,10 +1,10 @@
 [
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "default.replication.factor=1"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "min.insync.replicas=1"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.replication.factor=1"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.num.partitions=1"}
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "default.replication.factor=1"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "min.insync.replicas=1"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "offsets.topic.replication.factor=1"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "offsets.topic.num.partitions=1"}
 ]

--- a/variants/scale-1/kafka-scale1-overrides.json
+++ b/variants/scale-1/kafka-scale1-overrides.json
@@ -1,5 +1,7 @@
 [
   {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "zookeeper.connect=zoo-0.zoo.$(POD_NAMESPACE).svc.cluster.local:2181" },
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
   {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "default.replication.factor=1"},
   {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
   {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "min.insync.replicas=1"},

--- a/variants/scale-1/kustomization.yaml
+++ b/variants/scale-1/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-- ../../nonroot
+- ../../native
 patchesStrategicMerge:
 - kafka.yaml
 - zookeeper.yaml

--- a/variants/scale-1/zookeeper.yaml
+++ b/variants/scale-1/zookeeper.yaml
@@ -19,8 +19,8 @@ spec:
         env:
         - name: PZOO_REPLICAS
           value: '1'
-        - name: ZOO_REPLICAS
-          value: '0'
+        - name: REPLICAS
+          value: '1'
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -37,7 +37,12 @@ spec:
         # There's no validation on these numbers adding up to a coherent zk config, so watch out
         - name: PZOO_REPLICAS
           value: '1'
-        - name: ZOO_REPLICAS
-          value: '0'
+        - name: REPLICAS
+          value: '1'
         - name: ID_OFFSET
           value: '2'
+      containers:
+      - name: zookeeper
+        env:
+        - name: REPLICAS
+          value: '1'

--- a/variants/scale-1/zookeeper.yaml
+++ b/variants/scale-1/zookeeper.yaml
@@ -21,6 +21,11 @@ spec:
           value: '1'
         - name: REPLICAS
           value: '1'
+      containers:
+      - name: zookeeper
+        env:
+        - name: REPLICAS
+          value: '1'
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/variants/scale-2/kafka-scale2-overrides.json
+++ b/variants/scale-2/kafka-scale2-overrides.json
@@ -1,10 +1,10 @@
 [
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "default.replication.factor=2"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "min.insync.replicas=2"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.replication.factor=2"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.num.partitions=2"}
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "default.replication.factor=2"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "min.insync.replicas=2"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "offsets.topic.replication.factor=2"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "offsets.topic.num.partitions=2"}
 ]

--- a/variants/scale-2/zookeeper.yaml
+++ b/variants/scale-2/zookeeper.yaml
@@ -22,7 +22,12 @@ spec:
         # There's no validation on these numbers adding up to a coherent zk config, so watch out
         - name: PZOO_REPLICAS
           value: '0'
-        - name: ZOO_REPLICAS
+        - name: REPLICAS
           value: '2'
         - name: ID_OFFSET
           value: '1'
+      containers:
+      - name: zookeeper
+        env:
+        - name: REPLICAS
+          value: '2'

--- a/variants/scale-3-3/kafka-zookeeper-connect-only-zoo.json
+++ b/variants/scale-3-3/kafka-zookeeper-connect-only-zoo.json
@@ -1,0 +1,4 @@
+[
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "zookeeper.connect=zoo:2181"}
+]

--- a/variants/scale-3-3/kafka-zookeeper-connect-only-zoo.json
+++ b/variants/scale-3-3/kafka-zookeeper-connect-only-zoo.json
@@ -1,4 +1,6 @@
 [
   {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "zookeeper.connect=zoo:2181"}
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":
+    "zookeeper.connect=zoo-0.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-1.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-2.zoo.$(POD_NAMESPACE).svc.cluster.local:2181"
+  }
 ]

--- a/variants/scale-3-3/kustomization.yaml
+++ b/variants/scale-3-3/kustomization.yaml
@@ -1,0 +1,12 @@
+bases:
+- ../scale-3-5
+patchesStrategicMerge:
+- ./only-zoo-3.yaml
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: kafka
+    namespace: kafka
+  path: kafka-zookeeper-connect-only-zoo.json

--- a/variants/scale-3-3/only-zoo-3.yaml
+++ b/variants/scale-3-3/only-zoo-3.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pzoo
+  namespace: kafka
+spec:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zoo
+  namespace: kafka
+spec:
+  replicas: 3
+  template:
+    spec:
+      initContainers:
+      - name: init-config
+        env:
+        # There's no validation on these numbers adding up to a coherent zk config, so watch out
+        - name: PZOO_REPLICAS
+          value: '0'
+        - name: REPLICAS
+          value: '3'
+        - name: ID_OFFSET
+          value: '1'
+      containers:
+      - name: zookeeper
+        env:
+        - name: REPLICAS
+          value: '3'

--- a/variants/scale-3-5-nopzoo/kafka-zookeeper-connect-only-zoo.json
+++ b/variants/scale-3-5-nopzoo/kafka-zookeeper-connect-only-zoo.json
@@ -1,0 +1,4 @@
+[
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "zookeeper.connect=zoo:2181"}
+]

--- a/variants/scale-3-5-nopzoo/kustomization.yaml
+++ b/variants/scale-3-5-nopzoo/kustomization.yaml
@@ -2,3 +2,11 @@ bases:
 - ../scale-3-5
 patchesStrategicMerge:
 - ./only-zoo-5.yaml
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: kafka
+    namespace: kafka
+  path: kafka-zookeeper-connect-only-zoo.json

--- a/variants/scale-3-5-nopzoo/only-zoo-5.yaml
+++ b/variants/scale-3-5-nopzoo/only-zoo-5.yaml
@@ -22,7 +22,12 @@ spec:
         # There's no validation on these numbers adding up to a coherent zk config, so watch out
         - name: PZOO_REPLICAS
           value: '0'
-        - name: ZOO_REPLICAS
+        - name: REPLICAS
           value: '5'
         - name: ID_OFFSET
           value: '1'
+      containers:
+      - name: zookeeper
+        env:
+        - name: REPLICAS
+          value: '5'

--- a/variants/scale-6-9/kafka-6.yaml
+++ b/variants/scale-6-9/kafka-6.yaml
@@ -3,4 +3,4 @@ kind: StatefulSet
 metadata:
   name: kafka
 spec:
-  replicas: 3
+  replicas: 6

--- a/variants/scale-6-9/kafka-6.yaml
+++ b/variants/scale-6-9/kafka-6.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+spec:
+  replicas: 3

--- a/variants/scale-6-9/kafka-zookeeper-connect-only-zoo.json
+++ b/variants/scale-6-9/kafka-zookeeper-connect-only-zoo.json
@@ -1,0 +1,4 @@
+[
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "zookeeper.connect=zoo:2181"}
+]

--- a/variants/scale-6-9/kafka-zookeeper-connect-only-zoo.json
+++ b/variants/scale-6-9/kafka-zookeeper-connect-only-zoo.json
@@ -1,4 +1,6 @@
 [
   {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--override"},
-  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "zookeeper.connect=zoo:2181"}
+  {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":
+    "zookeeper.connect=zoo-0.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-1.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-2.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-3.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-4.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-5.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-6.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-7.zoo.$(POD_NAMESPACE).svc.cluster.local:2181,zoo-8.zoo.$(POD_NAMESPACE).svc.cluster.local:2181"
+  }
 ]

--- a/variants/scale-6-9/kustomization.yaml
+++ b/variants/scale-6-9/kustomization.yaml
@@ -4,6 +4,12 @@ patchesStrategicMerge:
 - zoo-9.yaml
 - kafka-6.yaml
 patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: kafka
+  path: kafka-zookeeper-connect-only-zoo.json
 # The nonroot image is distroless and doesn't support a shell that the prestop hook needs
 - target:
     group: apps

--- a/variants/scale-6-9/kustomization.yaml
+++ b/variants/scale-6-9/kustomization.yaml
@@ -1,0 +1,20 @@
+bases:
+- ../../native
+patchesStrategicMerge:
+- zoo-9.yaml
+- kafka-6.yaml
+patchesJson6902:
+# The nonroot image is distroless and doesn't support a shell that the prestop hook needs
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: zoo
+  path: lifecycle-remove.json
+# The nonroot image is distroless and has neither shell nor the nc command
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: zoo
+  path: zoo-readiness-without-shell.yaml

--- a/variants/scale-6-9/lifecycle-remove.json
+++ b/variants/scale-6-9/lifecycle-remove.json
@@ -1,0 +1,4 @@
+[
+  {"op": "remove", "path": "/spec/template/spec/containers/0/lifecycle"}
+]
+  

--- a/variants/scale-6-9/zoo-9.yaml
+++ b/variants/scale-6-9/zoo-9.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pzoo
+  namespace: kafka
+spec:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zoo
+  namespace: kafka
+spec:
+  replicas: 9
+  template:
+    spec:
+      initContainers:
+      - name: init-config
+        env:
+        # There's no validation on these numbers adding up to a coherent zk config, so watch out
+        - name: PZOO_REPLICAS
+          value: '0'
+        - name: REPLICAS
+          value: '9'
+        - name: ID_OFFSET
+          value: '1'
+      containers:
+      - name: zookeeper
+        env:
+        - name: REPLICAS
+          value: '9'

--- a/variants/scale-6-9/zoo-readiness-without-shell.yaml
+++ b/variants/scale-6-9/zoo-readiness-without-shell.yaml
@@ -1,0 +1,5 @@
+- op: replace
+  path: /spec/template/spec/containers/0/readinessProbe
+  value:
+    tcpSocket:
+      port: 2181

--- a/variants/scale-6-9/zoo-readiness-without-shell.yaml
+++ b/variants/scale-6-9/zoo-readiness-without-shell.yaml
@@ -1,5 +1,6 @@
-- op: replace
-  path: /spec/template/spec/containers/0/readinessProbe
-  value:
-    tcpSocket:
-      port: 2181
+- path: /spec/template/spec/containers/0/readinessProbe
+  # op: replace
+  # value:
+  #   tcpSocket:
+  #     port: 2181
+  op: remove

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -31,6 +31,8 @@ data:
     maxClientCnxns=2
     initLimit=5
     syncLimit=2
+    tcpKeepAlive=true
+    electionPortBindRetry=0
     server.1=pzoo-0.pzoo:2888:3888:participant
     server.2=pzoo-1.pzoo:2888:3888:participant
     server.3=pzoo-2.pzoo:2888:3888:participant

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -20,6 +20,7 @@ data:
       for N in $(seq $ZOO_REPLICAS); do echo "server.$(( $PZOO_REPLICAS + $N ))=zoo-$(( $N - 1 )).zoo:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
     }
     sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" /etc/kafka/zookeeper.properties
+    ln -s /etc/kafka/zookeeper.properties /etc/kafka/zookeeper.properties.$POD_NAME
 
   zookeeper.properties: |
     4lw.commands.whitelist=ruok

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -9,7 +9,7 @@ data:
     set -e
     set -x
 
-    [ -d /var/lib/zookeeper/data ] || mkdir /var/lib/zookeeper/data
+    [ ! -d /var/lib/zookeeper/data ] && mkdir -m 770 /var/lib/zookeeper/data && chgrp $(stat -c '%g' /var/lib/zookeeper) /var/lib/zookeeper/data
     [ -z "$ID_OFFSET" ] && ID_OFFSET=1
     export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + $ID_OFFSET))
     echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -17,7 +17,7 @@ data:
     [ ! -z "$PZOO_REPLICAS" ] && [ ! -z "$REPLICAS" ] && {
       sed -i "s/^server\\./#server./" /etc/kafka/zookeeper.properties
       for N in $(seq $PZOO_REPLICAS); do echo "server.$N=pzoo-$(( $N - 1 )).pzoo.$POD_NAMESPACE.svc.cluster.local:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
-      for N in $(seq $(( $REPLICAS - $PZOO_REPLICAS ))); do echo "server.$(( $PZOO_REPLICAS + $N ))=zoo-$(( $N - 1 )).$POD_NAMESPACE.svc.cluster.local:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
+      for N in $(seq $(( $REPLICAS - $PZOO_REPLICAS ))); do echo "server.$(( $PZOO_REPLICAS + $N ))=zoo-$(( $N - 1 )).zoo.$POD_NAMESPACE.svc.cluster.local:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
     }
     ln -s /etc/kafka/zookeeper.properties /etc/kafka/zookeeper.properties.scale-$REPLICAS.$POD_NAME
 

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -43,6 +43,5 @@ data:
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-    # Suppress connection log messages, three lines per livenessProbe execution
-    log4j.logger.org.apache.zookeeper.server.NIOServerCnxnFactory=WARN
+    # Suppress connection log messages, one line per readiness probe
     log4j.logger.org.apache.zookeeper.server.NIOServerCnxn=WARN

--- a/zookeeper/10zookeeper-config.yml
+++ b/zookeeper/10zookeeper-config.yml
@@ -14,11 +14,10 @@ data:
     export ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-} + $ID_OFFSET))
     echo "${ZOOKEEPER_SERVER_ID:-1}" | tee /var/lib/zookeeper/data/myid
     cp -Lur /etc/kafka-configmap/* /etc/kafka/
-    REPLICAS=$(( PZOO_REPLICAS + ZOO_REPLICAS ))
-    [ ! -z "$PZOO_REPLICAS" ] && [ ! -z "$ZOO_REPLICAS" ] && {
+    [ ! -z "$PZOO_REPLICAS" ] && [ ! -z "$REPLICAS" ] && {
       sed -i "s/^server\\./#server./" /etc/kafka/zookeeper.properties
       for N in $(seq $PZOO_REPLICAS); do echo "server.$N=pzoo-$(( $N - 1 )).pzoo:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
-      for N in $(seq $ZOO_REPLICAS); do echo "server.$(( $PZOO_REPLICAS + $N ))=zoo-$(( $N - 1 )).zoo:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
+      for N in $(seq $(( $REPLICAS - $PZOO_REPLICAS ))); do echo "server.$(( $PZOO_REPLICAS + $N ))=zoo-$(( $N - 1 )).zoo:2888:3888:participant" >> /etc/kafka/zookeeper.properties; done
     }
     sed -i "s/server\.$ZOOKEEPER_SERVER_ID\=[a-z0-9.-]*/server.$ZOOKEEPER_SERVER_ID=0.0.0.0/" /etc/kafka/zookeeper.properties
     ln -s /etc/kafka/zookeeper.properties /etc/kafka/zookeeper.properties.scale-$REPLICAS.$POD_NAME

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -25,6 +25,11 @@ spec:
       - name: init-config
         image: solsson/kafka-initutils@sha256:f6d9850c6c3ad5ecc35e717308fddb47daffbde18eb93e98e031128fe8b899ef
         command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         volumeMounts:
         - name: configmap
           mountPath: /etc/kafka-configmap
@@ -36,11 +41,15 @@ spec:
       - name: zookeeper
         image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         command:
         - ./bin/zookeeper-server-start.sh
-        - /etc/kafka/zookeeper.properties
+        - /etc/kafka/zookeeper.properties.$(POD_NAME)
         lifecycle:
           preStop:
             exec:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -26,6 +26,10 @@ spec:
         image: solsson/kafka-initutils@sha256:f6d9850c6c3ad5ecc35e717308fddb47daffbde18eb93e98e031128fe8b899ef
         command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: ID_OFFSET
           value: "4"
         volumeMounts:
@@ -39,11 +43,15 @@ spec:
       - name: zookeeper
         image: solsson/kafka:2.4.0@sha256:201a1c7fd378405b6b1bfd801127c8a530ed7a971282bfcee4ec731bc0c50ad2
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         command:
         - ./bin/zookeeper-server-start.sh
-        - /etc/kafka/zookeeper.properties
+        - /etc/kafka/zookeeper.properties.$(POD_NAME)
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
Use the command generated by Kafka's ./bin/*.sh as entrypoints. Given the same env these scripts simply produce the same command every time, and append args. See #309 and https://github.com/solsson/dockerfiles/blob/master/hooks/build.

Now things like #306 should be done with `--override`.