### PR TITLE
Rename the statefulset's headless service from broker to kafka

### DIFF
--- a/kafka/20dns.yml
+++ b/kafka/20dns.yml
@@ -3,9 +3,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: broker
+  name: kafka
   namespace: kafka
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
+  publishNotReadyAddresses: true
   ports:
   - port: 9092
   # [podname].broker.kafka.svc.cluster.local

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -7,7 +7,7 @@ spec:
   selector:
     matchLabels:
       app: kafka
-  serviceName: "broker"
+  serviceName: "kafka"
   replicas: 3
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
This allows DNS names to be used in args interpolation, for example:

```yaml
      - name: broker
        env:
        - name: POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        args:
        - /etc/kafka/server.properties.$(POD_NAME)
        - --override
        -   listeners=PLAINTEXT://$(POD_NAME).kafka:9092
```