### PR TITLE
Add partitions and replication-factor

### DIFF
--- a/kafka/test/kafkacat.yml
+++ b/kafka/test/kafkacat.yml
@@ -81,6 +81,10 @@ spec:
         - --if-not-exists
         - --topic
         -   test-kafkacat
+        - --partitions
+        -   "12"
+        - --replication-factor
+        -   "2"
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
Ran into failing tests due to a partition and replication-factor not being in place in the create if not exists clause.