### PR TITLE
Make sure topic create jobs use broker defaults

### DIFF
--- a/cruise-control/topic-create.yml
+++ b/cruise-control/topic-create.yml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka-cli@sha256:9fa3306e9f5d18283d10e01f7c115d8321eedc682f262aff784bd0126e1f2221
+        image: solsson/kafka:native-cli@sha256:7a4cc4ef875aea50b8d4dbb525cbac0ef3a5c6e611fcafc2c415ca432ebe5601
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper
@@ -17,10 +17,6 @@ spec:
         - --if-not-exists
         - --topic
         -   __CruiseControlMetrics
-        - --partitions
-        -   '12'
-        - --replication-factor
-        -   '3'
         resources:
           limits:
             cpu: 100m

--- a/events-kube/topic-create.yaml
+++ b/events-kube/topic-create.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka:2.1.0@sha256:ac3f06d87d45c7be727863f31e79fbfdcb9c610b51ba9cf03c75a95d602f15e1
+        image: solsson/kafka:native-cli@sha256:7a4cc4ef875aea50b8d4dbb525cbac0ef3a5c6e611fcafc2c415ca432ebe5601
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper
@@ -17,12 +17,8 @@ spec:
         - --if-not-exists
         - --topic
         -   ops.kube-events.stream.json
-        - --partitions
-        -   "12"
-        - --replication-factor
-        -   "2"
         resources:
           limits:
-            cpu: 200m
-            memory: 100Mi
+            cpu: 100m
+            memory: 20Mi
       restartPolicy: Never

--- a/kafka/test/kafkacat.yml
+++ b/kafka/test/kafkacat.yml
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka-cli@sha256:9fa3306e9f5d18283d10e01f7c115d8321eedc682f262aff784bd0126e1f2221
+        image: solsson/kafka:native-cli@sha256:7a4cc4ef875aea50b8d4dbb525cbac0ef3a5c6e611fcafc2c415ca432ebe5601
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper
@@ -83,8 +83,8 @@ spec:
         -   test-kafkacat
         resources:
           limits:
-            cpu: 200m
-            memory: 100Mi
+            cpu: 100m
+            memory: 20Mi
       restartPolicy: Never
 ---
 apiVersion: apps/v1

--- a/kafka/test/produce-consume.yml
+++ b/kafka/test/produce-consume.yml
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
       - name: topic-create
-        image: solsson/kafka-cli@sha256:9fa3306e9f5d18283d10e01f7c115d8321eedc682f262aff784bd0126e1f2221
+        image: solsson/kafka:native-cli@sha256:7a4cc4ef875aea50b8d4dbb525cbac0ef3a5c6e611fcafc2c415ca432ebe5601
         command:
         - ./bin/kafka-topics.sh
         - --zookeeper
@@ -64,14 +64,10 @@ spec:
         - --if-not-exists
         - --topic
         -   test-produce-consume
-        - --partitions
-        -   "3"
-        - --replication-factor
-        -   "2"
         resources:
           limits:
-            cpu: 200m
-            memory: 100Mi
+            cpu: 100m
+            memory: 20Mi
       restartPolicy: Never
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Investigates #323.

We should transition from --zookeeper to --bootstrap-server, but keep idempotence which means we'll probably need something like https://github.com/solsson/dockerfiles/blob/native/native/cli-scripts/kafka-topics_ifnotexists.sh.