### PR TITLE
Use k8s 1.17+ topology.kubernetes.io/zone for broker.rack

### DIFF
--- a/kafka/10broker-config.yml
+++ b/kafka/10broker-config.yml
@@ -18,7 +18,7 @@ data:
     hash kubectl 2>/dev/null || {
       SEDS+=("s/#init#broker.rack=#init#/#init#broker.rack=# kubectl not found in path/")
     } && {
-      ZONE=$(kubectl get node "$NODE_NAME" -o=go-template='{{index .metadata.labels "failure-domain.beta.kubernetes.io/zone"}}')
+      ZONE=$(kubectl get node "$NODE_NAME" -o=go-template='{{index .metadata.labels "topology.kubernetes.io/zone"}}')
       if [ "x$ZONE" == "x<no value>" ]; then
         SEDS+=("s/#init#broker.rack=#init#/#init#broker.rack=# zone label not found for node $NODE_NAME/")
       else


### PR DESCRIPTION
Deprecation notice: https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone
