### PR TITLE
Add namespace to kustomizations to support kustomize 3.5+

### DIFF
--- a/native/kustomization.yaml
+++ b/native/kustomization.yaml
@@ -8,10 +8,12 @@ patchesJson6902:
     version: v1
     kind: StatefulSet
     name: pzoo
+    namespace: kafka
   path: distroless.yaml
 - target:
     group: apps
     version: v1
     kind: StatefulSet
     name: zoo
+    namespace: kafka
   path: distroless.yaml

--- a/native/native-image-zookeeper.yaml
+++ b/native/native-image-zookeeper.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pzoo
+  namespace: kafka
 spec:
   template:
     spec:
@@ -17,6 +18,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: zoo
+  namespace: kafka
 spec:
   template:
     spec:

--- a/nonroot/kustomization.yaml
+++ b/nonroot/kustomization.yaml
@@ -11,34 +11,40 @@ patchesJson6902:
     version: v1
     kind: StatefulSet
     name: kafka
+    namespace: kafka
   path: fsgroup-65534.yaml
 - target:
     group: apps
     version: v1
     kind: StatefulSet
     name: pzoo
+    namespace: kafka
   path: fsgroup-65534.yaml
 - target:
     group: apps
     version: v1
     kind: StatefulSet
     name: zoo
+    namespace: kafka
   path: fsgroup-65534.yaml
 - target:
     group: apps
     version: v1
     kind: StatefulSet
     name: kafka
+    namespace: kafka
   path: entrypoint-from-image.yaml
 - target:
     group: apps
     version: v1
     kind: StatefulSet
     name: pzoo
+    namespace: kafka
   path: entrypoint-from-image.yaml
 - target:
     group: apps
     version: v1
     kind: StatefulSet
     name: zoo
+    namespace: kafka
   path: entrypoint-from-image.yaml

--- a/nonroot/nonroot-image-kafka.yaml
+++ b/nonroot/nonroot-image-kafka.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: kafka
+  namespace: kafka
 spec:
   template:
     spec:

--- a/nonroot/nonroot-image-zookeeper.yaml
+++ b/nonroot/nonroot-image-zookeeper.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pzoo
+  namespace: kafka
 spec:
   template:
     spec:
@@ -18,6 +19,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: zoo
+  namespace: kafka
 spec:
   template:
     spec:


### PR DESCRIPTION
Building on #302 I encountered the same error when trying to run `kustomize build nonroot` and `kustomize build native`. This resolves the issue and maintains compatibility for `kubectl kustomize nonroot` etc.