### PR TITLE
Add namespaces in nonroot base

### DIFF
--- a/nonroot/kustomization.yaml
+++ b/nonroot/kustomization.yaml
@@ -8,18 +8,21 @@ patchesJson6902:
     version: v1
     kind: StatefulSet
     name: kafka
+    namespace: kafka
   path: fsgroup-65534.yaml
 - target:
     group: apps
     version: v1
     kind: StatefulSet
     name: pzoo
+    namespace: kafka
   path: fsgroup-65534.yaml
 - target:
     group: apps
     version: v1
     kind: StatefulSet
     name: zoo
+    namespace: kafka
   path: fsgroup-65534.yaml
 # https://github.com/kubernetes-sigs/kustomize/issues/915#issuecomment-477808963
 patchesStrategicMerge:

--- a/nonroot/nonroot-image-kafka.yaml
+++ b/nonroot/nonroot-image-kafka.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: kafka
+  namespace: kafka
 spec:
   template:
     spec:

--- a/nonroot/nonroot-image-zookeeper.yaml
+++ b/nonroot/nonroot-image-zookeeper.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pzoo
+  namespace: kafka
 spec:
   template:
     spec:
@@ -13,6 +14,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: zoo
+  namespace: kafka
 spec:
   template:
     spec:


### PR DESCRIPTION
In short, this is the same issue as seen in https://github.com/Yolean/kubernetes-kafka/pull/302
`kubectl -k` (probably) works, but without specifying those namespaces `kustomize` is not able to merge the layers.