### PR TITLE
specified initContainers resources

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -22,6 +22,13 @@ spec:
       initContainers:
       - name: init-config
         image: solsson/kafka-initutils@sha256:f6d9850c6c3ad5ecc35e717308fddb47daffbde18eb93e98e031128fe8b899ef
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
         env:
         - name: NODE_NAME
           valueFrom:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -25,6 +25,13 @@ spec:
       - name: init-config
         image: solsson/kafka-initutils@sha256:f6d9850c6c3ad5ecc35e717308fddb47daffbde18eb93e98e031128fe8b899ef
         command: ['/bin/bash', '/etc/kafka-configmap/init.sh']
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+          limits:
+            cpu: 20m
+            memory: 120Mi
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
kubernetes version: 1.17.2

issue: when i deploy zookeeper and kafka. kubernetes report an event :  pods "zookeeper" : is forbidden: failed quota: must specified limits.cpu, limits.memory, requests.cpu, requests.memory。

fix: i specified initContainers resources, and it work