### PR TITLE
add Timeout to zookeeper readinessProbe

### DIFF
--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -72,6 +72,7 @@ spec:
           limits:
             memory: 120Mi
         readinessProbe:
+          timeoutSeconds: 10
           exec:
             command:
             - /bin/sh

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -74,6 +74,7 @@ spec:
           limits:
             memory: 120Mi
         readinessProbe:
+          timeoutSeconds: 10
           exec:
             command:
             - /bin/sh


### PR DESCRIPTION
As of Kubernetes 1.20 the default timeout for exec readiness probe is 1 second. Which in my cluster was not long enough for the netcat command to come back.
Timeouts for exec readiness probes are ignored in previous versions of Kubernetes. 

see note here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes