### PR TITLE
Fix Zookeeper readiness probe timeouts

### DIFF
--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -78,6 +78,7 @@ spec:
             - -c
             - '[ "imok" = "$(echo ruok | nc -w 1 -q 1 127.0.0.1 2181)" ]'
           timeoutSeconds: 2
+          periodSeconds: 30
         volumeMounts:
         - name: config
           mountPath: /etc/kafka

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -77,6 +77,7 @@ spec:
             - /bin/sh
             - -c
             - '[ "imok" = "$(echo ruok | nc -w 1 -q 1 127.0.0.1 2181)" ]'
+            timeoutSeconds: 2
         volumeMounts:
         - name: config
           mountPath: /etc/kafka

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -77,7 +77,7 @@ spec:
             - /bin/sh
             - -c
             - '[ "imok" = "$(echo ruok | nc -w 1 -q 1 127.0.0.1 2181)" ]'
-            timeoutSeconds: 2
+          timeoutSeconds: 2
         volumeMounts:
         - name: config
           mountPath: /etc/kafka

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -79,7 +79,7 @@ spec:
             - /bin/sh
             - -c
             - '[ "imok" = "$(echo ruok | nc -w 1 -q 1 127.0.0.1 2181)" ]'
-            timeoutSeconds: 2
+          timeoutSeconds: 2
         volumeMounts:
         - name: config
           mountPath: /etc/kafka

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -79,6 +79,7 @@ spec:
             - /bin/sh
             - -c
             - '[ "imok" = "$(echo ruok | nc -w 1 -q 1 127.0.0.1 2181)" ]'
+            timeoutSeconds: 2
         volumeMounts:
         - name: config
           mountPath: /etc/kafka

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -80,6 +80,7 @@ spec:
             - -c
             - '[ "imok" = "$(echo ruok | nc -w 1 -q 1 127.0.0.1 2181)" ]'
           timeoutSeconds: 2
+          periodSeconds: 30
         volumeMounts:
         - name: config
           mountPath: /etc/kafka


### PR DESCRIPTION
kubectl describe on our zookeeper pods occasionally logged `Warning  Unhealthy  12s (x18 over 3m32s)  kubelet            Readiness probe errored: rpc error: code = DeadlineExceeded desc = failed to exec in container: timeout 1s exceeded: context deadline exceeded`. The Kafka cluster was still healthy, but we noticed that on Containerd nodes every such timeout left a process like this one:

```
root     2973844   16185  0 Feb10 ?        00:00:00 [sh] <defunct>
```

(on newer kafka clusters the user is [nonroot](https://github.com/Yolean/kubernetes-kafka/tree/master/nonroot) instead of root)

These processes stayed around forever, so that long lived nodes eventuall hit their thread limit. The reason we hadn't noticed the issue earlier was that, until recently, all our long lived nodes ran Dockerd.